### PR TITLE
#20 - Dependency Injection: Add default request headers for Scryfall …

### DIFF
--- a/MtgCsvHelper/ServiceConfiguration.cs
+++ b/MtgCsvHelper/ServiceConfiguration.cs
@@ -8,7 +8,19 @@ public static class ServiceConfiguration
 {
 	public static IServiceCollection ConfigureMtgCsvHelper(this IServiceCollection services)
 	{
-		services.AddScryfallApiClient();
+		// Before, we used default method services.AddScryfallApiClient() instead of injecting our own manually configured client.
+		// However, this no longer works since the wrapped client does not set the required DefaultRequestHeaders, and the Scryfall API now requires them.
+		// ScryfallApiClientConfig parameter also provides no access to DefaultRequestHeaders.
+		// services.AddScryfallApiClient();
+
+		services.AddHttpClient<ScryfallApiClient>(client =>
+		{
+			client.BaseAddress = new Uri("https://api.scryfall.com/");
+			client.DefaultRequestHeaders.Add("User-Agent", "MtgCsvHelper/1.0.0");
+			client.DefaultRequestHeaders.Add("Accept", "application/json");
+
+		});
+
 		services.AddSingleton(ScryfallApiClientConfig.GetDefault());
 		services.AddSingleton<IMtgApi, CachedMtgApi>();
 		return services;

--- a/MtgCsvHelper/Services/CachedMtgApi.cs
+++ b/MtgCsvHelper/Services/CachedMtgApi.cs
@@ -35,18 +35,22 @@ public class CachedMtgApi : IMtgApi
 
 	public async Task LoadData()
 	{
+		Log.Debug($"Scryfall - Syncing data...");
 		_sets ??= (await GetSetsAsync()).ToList();
+
 		_doubleFacedCardNames ??= await GetDoubleFacedCardNamesAsync();
+		Log.Debug($"Scryfall - Loaded {_doubleFacedCardNames.Count} double-faced cards.");
+
 		_tokenCardNames ??= (await GetTokenCardNamesAsync()).Select(c => c.Name).Distinct().ToList();
+
+		Log.Debug($"Scryfall - Loaded {_tokenCardNames.Count} tokens.");
+		Log.Debug($"Scryfall - Sync complete.");
 	}
 
 	public async Task<List<string>> GetDoubleFacedCardNamesAsync()
 	{
 		var cards = await _api.Catalogs.ListCardNames();
 		var names = cards.Where(name => name.Contains(" // ")).ToList() ?? [];
-
-		Console.WriteLine($"Loaded {names.Count} double-faced cards from server");
-		Log.Debug($"Loaded {names.Count} double-faced cards from server");
 
 		return names;
 	}


### PR DESCRIPTION
…HttpClient

- There was a previous change for this in commit 2f36904
- It was only active for GetTokenCardNamesAsync
- unclear why it worked in Blazor, but not Console for other endpoints

Fixes #20 