### PR TITLE
[#26] FIX - Extended list of converted languages

### DIFF
--- a/MtgCsvHelper/Converters/LanguageConverter.cs
+++ b/MtgCsvHelper/Converters/LanguageConverter.cs
@@ -17,7 +17,11 @@ public class LanguageConverter(LanguageConfiguration configuration) : ITypeConve
 		["German"] = "de",
 		["Italian"] = "it",
 		["Portuguese"] = "pt",
-		["Japanese"] = "jp",
+		["Japanese"] = "ja", // Attention - different than 2 letter country code (jp)
+		["Korean"] = "ko",
+		["Russian"] = "ru",
+		["Chinese"] = "zhs", // Simplified Chinese
+		["Traditional Chinese"] = "zht",
 	};
 
 	readonly bool _useShortNames = configuration.ShortNames;


### PR DESCRIPTION
- Fixed: Japanese (jp -> ja)
- Added: Korean, Russian, Chinese (Simplified and Traditional)