### PR TITLE
Refactor: remove IMtgApi.Default service locator, Blazor naming, CI fixes

### DIFF
--- a/.claude/findings.md
+++ b/.claude/findings.md
@@ -1,0 +1,90 @@
+# Code Review Findings
+
+## High Priority
+
+### ✅ 1. Static `IMtgApi.Default` — service locator anti-pattern
+**File**: `MtgCsvHelper/Services/IMtgApi.cs`
+~~`CardNameConverter` reached into a global static property instead of receiving the API through DI.~~
+
+**Fixed**: `IMtgApi` is now threaded through `CardMapFactory.GenerateClassMap` → `PhysicalCardMap` →
+`CardNameConverter`. The `static Default` property and `// FIXME` comment are deleted. Both `Program.cs`
+files and `MtgApiFixture` no longer set it.
+
+---
+
+### ✅ 2. CI workflow uses wrong .NET version
+**File**: `.github/workflows/dotnet.yml`
+~~Build and test pipeline still targets `9.0.x` while the projects target `net10.0`.~~
+
+**Fixed**: Updated `dotnet-version` to `10.0.x`. Also restricted GitHub Pages deploy to
+`main` branch pushes only.
+
+---
+
+## Medium Priority
+
+### 3. Dead code — `IMtgCardCsvHandlerService`
+**Files**: `MtgCsvHelper/Services/IMtgCardCsvHandlerService.cs` and
+`MtgCsvHelper/Services/MtgCardCsvHandlerService.cs`
+Interface and implementation exist but are never registered in DI or used anywhere.
+
+**Fix**: Delete both files.
+
+---
+
+### 4. Serilog not working in Blazor Program.cs
+**File**: `MtgCsvHelper.BlazorWebAssembly/Program.cs`
+- ✅ Dead debug variables (`csvConfigs`, `deckConfigsBuilder`) removed
+- `Log.Information("Hello, Blazor, Serilog online!")` never appears — root cause unknown
+
+**Likely cause**: Blazor WASM needs `Serilog.Sinks.BrowserConsole` (WriteTo.BrowserConsole) instead of
+the standard console sink. The appsettings.json sink config may be targeting a sink that doesn't work
+in-browser. Needs investigation.
+
+---
+
+### 5. Test coverage gaps
+**File**: `MtgCsvHelper.Tests/`
+- No tests for error cases: malformed CSV, invalid format names, missing required columns
+- Deckbox round-trip test is commented out (`MtgCardCsvHandlerTests.cs:39`)
+- ✅ Scryfall rate limiting fixed (shared `MtgApiFixture` via `ICollectionFixture`)
+- ✅ `BaseTest` / `ApiBaseTest` split for clean test hierarchy
+- No component tests for Blazor (tracked separately as task #1 — bUnit)
+
+---
+
+### 6. Improve error messages in `CardMapFactory`
+**File**: `MtgCsvHelper/CardMapFactory.cs:20`
+`GenerateClassMap` returns `null` for unsupported formats. Callers have to handle null
+silently. Should throw a descriptive exception listing supported formats instead.
+
+---
+
+## Low Priority
+
+### 7. TODO/tech debt scattered across codebase
+- `Converters/CardNameConverter.cs:35` — Token encoding for Moxfield not implemented
+- `Models/Collection.cs:28` — Rarity stats commented out, waiting for Scryfall enrichment
+- `BlazorWebAssembly/Pages/MtgCsvProcessor.razor:16` — Multiple file upload not implemented
+- `Console/Program.cs:46` — Error handling for CLI parse errors is a stub
+
+### 8. `CardCondition` EnumClass pattern is verbose
+**File**: `MtgCsvHelper/Models/CardCondition.cs`
+Custom `EnumClass` base is unnecessarily complex. Could be a simple record hierarchy
+or a string-keyed static class.
+
+### 9. `MtgCardCsvHandler.ParseCollectionCsv` logs wrong value
+**File**: `MtgCsvHelper/MtgCardCsvHandler.cs:27`
+`Log.Information($"Parsing {csvFilePath} ...")` — when called with a `Stream`,
+this logs the stream's type name, not something useful. Should log the format name instead.
+
+---
+
+## Other Completed Work (not tracked as findings above)
+
+- ✅ Upgraded to .NET 10, updated all NuGet packages
+- ✅ Replaced FluentAssertions with AwesomeAssertions
+- ✅ Moved CLAUDE.md to `.claude/` folder
+- ✅ `DeckConfig.SetNumber` made nullable (.NET 10 ConfigurationBinder breaking change)
+- ✅ `WriteCollectionCsv` stream overload — Blazor no longer uses VFS roundtrip
+- ✅ `_camelCase` private field naming enforced in editorconfig and applied to Razor component

--- a/.editorconfig
+++ b/.editorconfig
@@ -207,6 +207,16 @@ dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
 dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
 dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
 
+dotnet_naming_rule.private_fields_should_be_underscore_camel_case.severity = suggestion
+dotnet_naming_rule.private_fields_should_be_underscore_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_underscore_camel_case.style = underscore_camel_case
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.underscore_camel_case.required_prefix = _
+dotnet_naming_style.underscore_camel_case.capitalization = camel_case
+
 dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.types_should_be_pascal_case.symbols = types
 dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -1,4 +1,4 @@
-﻿@page "/"
+@page "/"
 @inject IConfiguration Config
 @inject IMtgApi Api
 @inject IJSRuntime JS
@@ -23,8 +23,8 @@
 			<label for="inputFormat">Select Input Format:</label>
 		</div>
 		<div class="col-md-9">
-			<InputSelect id="inputFormat" @bind-Value="selectedInputFormat">
-				@foreach (var deckFormat in SUPPORTED_FORMATS)
+			<InputSelect id="inputFormat" @bind-Value="_selectedInputFormat">
+				@foreach (var deckFormat in _supportedFormats)
 				{
 					<option>@deckFormat</option>
 				}
@@ -37,8 +37,8 @@
 			<label for="outputFormat">Select Output Format:</label>
 		</div>
 		<div class="col-md-9">
-			<InputSelect id="outputFormat" @bind-Value="selectedOutputFormat">
-				@foreach (var deckFormat in SUPPORTED_FORMATS)
+			<InputSelect id="outputFormat" @bind-Value="_selectedOutputFormat">
+				@foreach (var deckFormat in _supportedFormats)
 				{
 					<option>@deckFormat</option>
 				}
@@ -48,8 +48,8 @@
 
 	<div class="form-group row">
 		<div class="col-md-3 text-end">
-			<button @onclick="Convert" disabled="@(csvFile is null)" class="btn btn-primary">
-				@if (isConverting)
+			<button @onclick="Convert" disabled="@(_csvFile is null)" class="btn btn-primary">
+				@if (_isConverting)
 				{
 					<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
 					<span class="visually-hidden">Processing...</span>
@@ -62,7 +62,7 @@
 			</button>
 		</div>
 		<div class="col-md-9">
-			@if (!isConverting && processedRecords.Any())
+			@if (!_isConverting && _processedRecords.Any())
 			{
 				<button class="btn btn-success" @onclick="DownloadResult">Download Converted .csv</button>
 			}
@@ -71,17 +71,17 @@
 </div>
 
 
-@if (!string.IsNullOrEmpty(summary))
+@if (!string.IsNullOrEmpty(_summary))
 {
-	<p style="white-space: pre-line" >@summary</p>
+	<p style="white-space: pre-line" >@_summary</p>
 }
 
-@if (processedRecords.Any())
+@if (_processedRecords.Any())
 {
 	<h4>Processed Records</h4>
 	<!-- Display the processed records as needed -->
 	<ul>
-		@foreach (var record in processedRecords)
+		@foreach (var record in _processedRecords)
 		{
 			<li>@record</li>
 		}
@@ -89,26 +89,25 @@
 }
 
 @code {
-	private static int MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
-	private static List<string> SUPPORTED_FORMATS = CardMapFactory.Supported;
+	private static readonly int _maxFileSize = 5 * 1024 * 1024; // 5MB
+	private static readonly List<string> _supportedFormats = CardMapFactory.Supported;
 
-	private string selectedInputFormat = SUPPORTED_FORMATS[0];
-	private string selectedOutputFormat = SUPPORTED_FORMATS[1];
+	private string _selectedInputFormat = _supportedFormats[0];
+	private string _selectedOutputFormat = _supportedFormats[1];
 
-	private List<string> processedRecords = [];
-	private IBrowserFile? csvFile;
+	private List<string> _processedRecords = [];
+	private IBrowserFile? _csvFile;
 
-
-	private string? summary;
-	private bool isConverting;
-	private string? resultFileName;
-	private MemoryStream? resultStream;
+	private string? _summary;
+	private bool _isConverting;
+	private string? _resultFileName;
+	private MemoryStream? _resultStream;
 
 	private async Task HandleFileUpload(InputFileChangeEventArgs e)
 	{
 		// Store the file for later use
 		// TODO GetMultipleFiles() support
-		csvFile = e.File;
+		_csvFile = e.File;
 		await Api.LoadData();
 	}
 
@@ -116,52 +115,47 @@
 	{
 		try
 		{
-			isConverting = true;
+			_isConverting = true;
 			StateHasChanged();
 			await Task.Delay(1);
 
 			Stream csvStream = new MemoryStream();
-			// We need an async stream to read the file contents
-
-			await csvFile!.OpenReadStream(maxAllowedSize: MAX_FILE_SIZE).CopyToAsync(csvStream);
-			// Reset the stream position so we can read it
+			await _csvFile!.OpenReadStream(maxAllowedSize: _maxFileSize).CopyToAsync(csvStream);
 			csvStream.Position = 0;
 
-			var reader = new MtgCardCsvHandler(Api, Config, selectedInputFormat);
-			var writer = new MtgCardCsvHandler(Api, Config, selectedOutputFormat);
+			var reader = new MtgCardCsvHandler(Api, Config, _selectedInputFormat);
+			var writer = new MtgCardCsvHandler(Api, Config, _selectedOutputFormat);
 
 			var collection = reader.ParseCollectionCsv(csvStream);
-			summary = collection.GenerateSummary();
-			Console.WriteLine(summary);
-			
-			var cards = collection.Cards;
-			processedRecords = cards.Select(c => c.Printing.Name).ToList();
-			resultFileName ??= $"{selectedInputFormat}-to-{selectedOutputFormat}_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv";
-			resultStream = new MemoryStream();
-			writer.WriteCollectionCsv(cards, resultStream);
+			_summary = collection.GenerateSummary();
 
+			var cards = collection.Cards;
+			_processedRecords = cards.Select(c => c.Printing.Name).ToList();
+			_resultFileName ??= $"{_selectedInputFormat}-to-{_selectedOutputFormat}_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv";
+			_resultStream = new MemoryStream();
+			writer.WriteCollectionCsv(cards, _resultStream);
 		}
 		catch (Exception ex)
 		{
-			summary = $"Unexpected error converting file: {ex.Message} \n {ex.StackTrace}";
+			_summary = $"Unexpected error converting file: {ex.Message} \n {ex.StackTrace}";
 		}
 		finally
 		{
-			isConverting = false;
+			_isConverting = false;
 			StateHasChanged();
 		}
 	}
 
 	private async Task DownloadResult()
 	{
-		if (resultStream is null || string.IsNullOrEmpty(resultFileName))
+		if (_resultStream is null || string.IsNullOrEmpty(_resultFileName))
 		{
 			Log.Warning("No result available, this should not happen");
 			return;
 		}
 
-		resultStream.Position = 0;
-		using var streamRef = new DotNetStreamReference(stream: resultStream, leaveOpen: true);
-		await JS.InvokeVoidAsync("downloadFileFromStream", resultFileName, streamRef);
+		_resultStream.Position = 0;
+		using var streamRef = new DotNetStreamReference(stream: _resultStream, leaveOpen: true);
+		await JS.InvokeVoidAsync("downloadFileFromStream", _resultFileName, streamRef);
 	}
 }

--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -4,6 +4,7 @@
 @inject IJSRuntime JS
 @using Serilog
 @using System.Text
+@implements IDisposable
 
 <h3 class="mb-4">Convert your MtG collection .csv file</h3>
 
@@ -89,8 +90,8 @@
 }
 
 @code {
-	private static readonly int _maxFileSize = 5 * 1024 * 1024; // 5MB
-	private static readonly List<string> _supportedFormats = CardMapFactory.Supported;
+	private const int MaxFileSize = 5 * 1024 * 1024; // 5MB
+	private static readonly IReadOnlyList<string> _supportedFormats = CardMapFactory.Supported;
 
 	private string _selectedInputFormat = _supportedFormats[0];
 	private string _selectedOutputFormat = _supportedFormats[1];
@@ -120,7 +121,7 @@
 			await Task.Delay(1);
 
 			Stream csvStream = new MemoryStream();
-			await _csvFile!.OpenReadStream(maxAllowedSize: _maxFileSize).CopyToAsync(csvStream);
+			await _csvFile!.OpenReadStream(maxAllowedSize: MaxFileSize).CopyToAsync(csvStream);
 			csvStream.Position = 0;
 
 			var reader = new MtgCardCsvHandler(Api, Config, _selectedInputFormat);
@@ -131,13 +132,14 @@
 
 			var cards = collection.Cards;
 			_processedRecords = cards.Select(c => c.Printing.Name).ToList();
-			_resultFileName ??= $"{_selectedInputFormat}-to-{_selectedOutputFormat}_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv";
+			_resultFileName = $"{_selectedInputFormat}-to-{_selectedOutputFormat}_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv";
+			_resultStream?.Dispose();
 			_resultStream = new MemoryStream();
 			writer.WriteCollectionCsv(cards, _resultStream);
 		}
 		catch (Exception ex)
 		{
-			_summary = $"Unexpected error converting file: {ex.Message} \n {ex.StackTrace}";
+			_summary = $"Unexpected error converting file: {ex.Message}";
 		}
 		finally
 		{
@@ -157,5 +159,10 @@
 		_resultStream.Position = 0;
 		using var streamRef = new DotNetStreamReference(stream: _resultStream, leaveOpen: true);
 		await JS.InvokeVoidAsync("downloadFileFromStream", _resultFileName, streamRef);
+	}
+
+	public void Dispose()
+	{
+		_resultStream?.Dispose();
 	}
 }

--- a/MtgCsvHelper.BlazorWebAssembly/Program.cs
+++ b/MtgCsvHelper.BlazorWebAssembly/Program.cs
@@ -21,15 +21,10 @@ var host = builder.Build();
 var config = builder.Configuration;
 
 Log.Logger = new LoggerConfiguration().ReadFrom.Configuration(config).CreateLogger();
-// TODO Figure out why serilog does not want to work
+// TODO Figure out why Serilog does not want to work
 Log.Information("Hello, Blazor, Serilog online!");
 
-// TODO Everything below is just for debugging dependency injection, remove when stable
-var csvConfigs = config.GetSection("CsvConfigurations");
-var deckConfigsBuilder = CardMapFactory.From(config).ToList();
-
 var api = host.Services.GetService<IMtgApi>()!;
-IMtgApi.Default = api;
 await api.LoadData();
 
 await host.RunAsync();

--- a/MtgCsvHelper.Console/Program.cs
+++ b/MtgCsvHelper.Console/Program.cs
@@ -17,7 +17,6 @@ Log.Logger = new LoggerConfiguration().ReadFrom.Configuration(config).CreateLogg
 
 var api = host.Services.GetService<IMtgApi>()!;
 await api.LoadData();
-IMtgApi.Default = api;
 
 Parser.Default.ParseArguments<CommandLineOptions>(args)
 	.WithNotParsed(HandleParseError)

--- a/MtgCsvHelper.Tests/DeckFormatTests.cs
+++ b/MtgCsvHelper.Tests/DeckFormatTests.cs
@@ -12,7 +12,7 @@ public class DeckFormatTests(MtgApiFixture fixture, ITestOutputHelper output) : 
 	//[InlineData("CARDKINGDOM")]
 	public void SupportedTest(string deckFormatName)
 	{
-		var classMap = new CardMapFactory(_config).GenerateClassMap(deckFormatName);
+		var classMap = new CardMapFactory(_config).GenerateClassMap(deckFormatName, _api);
 		classMap.Should().NotBeNull();
 	}
 }

--- a/MtgCsvHelper.Tests/DeckFormatTests.cs
+++ b/MtgCsvHelper.Tests/DeckFormatTests.cs
@@ -1,3 +1,5 @@
+using ScryfallApi.Client.Models;
+
 namespace MtgCsvHelper.Tests;
 
 [Collection(MtgApiCollection.Name)]
@@ -12,7 +14,32 @@ public class DeckFormatTests(MtgApiFixture fixture, ITestOutputHelper output) : 
 	//[InlineData("CARDKINGDOM")]
 	public void SupportedTest(string deckFormatName)
 	{
-		var classMap = new CardMapFactory(_config).GenerateClassMap(deckFormatName, _api);
+		var classMap = new CardMapFactory(_config, _api).GenerateClassMap(deckFormatName);
 		classMap.Should().NotBeNull();
+	}
+
+	[Theory]
+	[InlineData("DRAGONSHIELD")]
+	[InlineData("MOXFIELD")]
+	[InlineData("MANABOX")]
+	[InlineData("TOPDECKED")]
+	[InlineData("DECKBOX")]
+	public void StreamRoundTripTest(string deckFormatName)
+	{
+		var handler = new MtgCardCsvHandler(_api, _config, deckFormatName);
+		var original = new List<PhysicalMtgCard>
+		{
+			new() { Count = 2, Printing = new Card { Name = "Lightning Bolt", Set = "M11", SetName = "Magic 2011", CollectorNumber = "149" } }
+		};
+
+		var stream = new MemoryStream();
+		handler.WriteCollectionCsv(original, stream);
+		stream.Position = 0;
+
+		var parsed = handler.ParseCollectionCsv(stream).Cards;
+
+		parsed.Should().HaveCount(1);
+		parsed[0].Printing.Name.Should().Be("Lightning Bolt");
+		parsed[0].Count.Should().Be(2);
 	}
 }

--- a/MtgCsvHelper.Tests/MtgApiFixture.cs
+++ b/MtgCsvHelper.Tests/MtgApiFixture.cs
@@ -13,7 +13,6 @@ public class MtgApiFixture : IAsyncLifetime
 		Log.Logger = AppLogging.GetDefaultLoggerConfig.CreateLogger();
 		Api = new CachedMtgApi(new ScryfallApiClient(CachedMtgApi.DEFAULT_CLIENT));
 		await Api.LoadData();
-		IMtgApi.Default = Api;
 	}
 
 	// HttpClient disposal intentionally skipped — acceptable for test fixtures

--- a/MtgCsvHelper/CardMapFactory.cs
+++ b/MtgCsvHelper/CardMapFactory.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using MtgCsvHelper.Maps;
+using MtgCsvHelper.Services;
 
 namespace MtgCsvHelper;
 
@@ -17,5 +18,5 @@ public class CardMapFactory(IConfiguration config)
 
 	public DeckConfig? GetDeckConfig(string format) => _deckConfigs.FirstOrDefault(c => c.Name.Equals(format));
 
-	public PhysicalCardMap? GenerateClassMap(string format) => GetDeckConfig(format) is DeckConfig dc ? new(dc, format.Equals("CARDKINGDOM")) : null;
+	public PhysicalCardMap? GenerateClassMap(string format, IMtgApi api) => GetDeckConfig(format) is DeckConfig dc ? new(dc, format.Equals("CARDKINGDOM"), api) : null;
 }

--- a/MtgCsvHelper/CardMapFactory.cs
+++ b/MtgCsvHelper/CardMapFactory.cs
@@ -4,7 +4,7 @@ using MtgCsvHelper.Services;
 
 namespace MtgCsvHelper;
 
-public class CardMapFactory(IConfiguration config)
+public class CardMapFactory(IConfiguration config, IMtgApi api)
 {
 	readonly List<DeckConfig> _deckConfigs = From(config).ToList();
 
@@ -18,5 +18,5 @@ public class CardMapFactory(IConfiguration config)
 
 	public DeckConfig? GetDeckConfig(string format) => _deckConfigs.FirstOrDefault(c => c.Name.Equals(format));
 
-	public PhysicalCardMap? GenerateClassMap(string format, IMtgApi api) => GetDeckConfig(format) is DeckConfig dc ? new(dc, format.Equals("CARDKINGDOM"), api) : null;
+	public PhysicalCardMap? GenerateClassMap(string format) => GetDeckConfig(format) is DeckConfig dc ? new(dc, format.Equals("CARDKINGDOM"), api) : null;
 }

--- a/MtgCsvHelper/Converters/CardNameConverter.cs
+++ b/MtgCsvHelper/Converters/CardNameConverter.cs
@@ -5,13 +5,13 @@ using MtgCsvHelper.Services;
 
 namespace MtgCsvHelper.Converters;
 
-public class CardNameConverter(CardNameConfiguration configuration) : ITypeConverter
+public class CardNameConverter(CardNameConfiguration configuration, IMtgApi api) : ITypeConverter
 {
 	readonly bool _useShortNames = configuration.ShortNames;
 	readonly bool _encodeToken = configuration.EncodeToken;
 
-	readonly HashSet<string> _doubleFacedCards = IMtgApi.Default.GetDoubleFacedCardNames().ToHashSet();
-	readonly HashSet<string> _tokenCards = IMtgApi.Default.GetTokenCardNames().ToHashSet();
+	readonly HashSet<string> _doubleFacedCards = api.GetDoubleFacedCardNames().ToHashSet();
+	readonly HashSet<string> _tokenCards = api.GetTokenCardNames().ToHashSet();
 
 	public object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
 	{

--- a/MtgCsvHelper/Maps/PhysicalCardMap.cs
+++ b/MtgCsvHelper/Maps/PhysicalCardMap.cs
@@ -1,27 +1,28 @@
 ﻿using CsvHelper.Configuration;
 using MtgCsvHelper.Converters;
+using MtgCsvHelper.Services;
 
 namespace MtgCsvHelper.Maps;
 
 public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 {
-    public PhysicalCardMap(DeckConfig columnConfig, bool ck)
+    public PhysicalCardMap(DeckConfig columnConfig, bool ck, IMtgApi api)
     {
         // Yes it is ugly. No I dont care. F#!& you CardKingdom!
         if (ck)
         {
-            ConfigureCK(columnConfig);
+            ConfigureCK(columnConfig, api);
         }
         else
         {
-            ConfigureMaps(columnConfig);
+            ConfigureMaps(columnConfig, api);
         }
     }
 
-    void ConfigureMaps(DeckConfig columnConfig)
+    void ConfigureMaps(DeckConfig columnConfig, IMtgApi api)
     {
         Map(card => card.Count).Name(columnConfig.Quantity).Index(1);
-        Map(card => card.Printing.Name).TypeConverter(new CardNameConverter(columnConfig.CardName)).Name(columnConfig.CardName.HeaderName).Index(0);
+        Map(card => card.Printing.Name).TypeConverter(new CardNameConverter(columnConfig.CardName, api)).Name(columnConfig.CardName.HeaderName).Index(0);
         if (columnConfig.SetNumber is not null) { Map(card => card.Printing.CollectorNumber).Name(columnConfig.SetNumber).Optional(); }
 
         // We implicitly assume that at least one of them is present (some sites use SetName, some use SetCode, some use both...)
@@ -34,9 +35,9 @@ public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
         if (columnConfig.PriceBought is PriceConfiguration price) { Map(card => card.PriceBought).TypeConverter(new PriceConverter(price)).Name(price.HeaderName).Optional(); }
     }
 
-    void ConfigureCK(DeckConfig columnConfig)
+    void ConfigureCK(DeckConfig columnConfig, IMtgApi api)
     {
-        Map(card => card.Printing.Name).TypeConverter(new CardNameConverter(columnConfig.CardName)).Name(columnConfig.CardName.HeaderName).Index(0);
+        Map(card => card.Printing.Name).TypeConverter(new CardNameConverter(columnConfig.CardName, api)).Name(columnConfig.CardName.HeaderName).Index(0);
         if (columnConfig.SetName is not null) { Map(card => card.Printing.SetName).TypeConverter<UpperCaseConverter>().Name(columnConfig.SetName).Index(1); }
         Map(card => card.Foil).TypeConverter(new FinishConverter(columnConfig.Finish!)).Name(columnConfig.Finish!.HeaderName).Index(2);
         Map(card => card.Count).Name(columnConfig.Quantity).Index(3);

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -14,7 +14,7 @@ public class MtgCardCsvHandler
 	public MtgCardCsvHandler(IMtgApi api, IConfiguration config, string format)
 	{
 		_format = format;
-		_classMap = new CardMapFactory(config).GenerateClassMap(format) ?? throw new ArgumentException($"Unsupported {format} - not found in configuration file");
+		_classMap = new CardMapFactory(config).GenerateClassMap(format, api) ?? throw new ArgumentException($"Unsupported {format} - not found in configuration file");
 		_api = api;
 	}
 

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -14,7 +14,7 @@ public class MtgCardCsvHandler
 	public MtgCardCsvHandler(IMtgApi api, IConfiguration config, string format)
 	{
 		_format = format;
-		_classMap = new CardMapFactory(config).GenerateClassMap(format, api) ?? throw new ArgumentException($"Unsupported {format} - not found in configuration file");
+		_classMap = new CardMapFactory(config, api).GenerateClassMap(format) ?? throw new ArgumentException($"Unsupported {format} - not found in configuration file");
 		_api = api;
 	}
 

--- a/MtgCsvHelper/Services/IMtgApi.cs
+++ b/MtgCsvHelper/Services/IMtgApi.cs
@@ -4,9 +4,6 @@ namespace MtgCsvHelper.Services;
 
 public interface IMtgApi
 {
-	// FIXME Workaround since it is currently annoying to pass IMtgApi to CardNameConverter instance through DI
-	static IMtgApi Default { get; set; }
-
 	IEnumerable<Set> GetSets();
 	Task<IEnumerable<Set>> GetSetsAsync();
 


### PR DESCRIPTION
## Summary

- Remove `IMtgApi.Default` static service locator anti-pattern — `IMtgApi` is now threaded explicitly through `CardMapFactory.GenerateClassMap` → `PhysicalCardMap` → `CardNameConverter`
- Enforce `_camelCase` private field naming in `.editorconfig`, applied to Razor component
- Write CSV output to `MemoryStream` in Blazor instead of VFS roundtrip; add `Stream` overload to `WriteCollectionCsv`
- Clean up dead debug variables in Blazor `Program.cs`
- Update CI test workflow (`dotnet.yml`) to .NET 10
- Add code review findings to `.claude/findings.md`

## Test plan

- [ ] All existing tests pass
- [ ] Blazor app builds and CSV conversion still works end-to-end
- [ ] File download in browser works correctly