### PR TITLE
Refactor classmaps to remove CARDKINGDOM boolean flag

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,7 +34,7 @@ dotnet run --project MtgCsvHelper.Console
 ## Conventions
 
 - File-scoped namespaces (`csharp_style_namespace_declarations = file_scoped`)
-- 4 spaces indentation for C#, 2 spaces for XML/csproj
+- Tabs (width 4) for C#, 2 spaces for XML/csproj
 - Allman brace style (opening brace on new line)
 - PascalCase for types and public members, `_camelCase` for private fields
 - Interfaces prefixed with `I`

--- a/.claude/findings.md
+++ b/.claude/findings.md
@@ -10,12 +10,6 @@
 
 ---
 
-### 6. Improve error messages in `CardMapFactory`
-**File**: `MtgCsvHelper/CardMapFactory.cs:20`
-`GenerateClassMap` returns `null` for unsupported formats. Callers have to handle null
-silently. Should throw a descriptive exception listing supported formats instead.
-
----
 
 ### 16. `LoadData()` `??=` assignments are not thread-safe
 **File**: `MtgCsvHelper/Services/CachedMtgApi.cs`
@@ -62,6 +56,7 @@ this logs the stream's type name, not something useful. Should log the format na
 - ✅ **#3** Deleted dead `IMtgCardCsvHandlerService` / `MtgCardCsvHandlerService`
 - ✅ **#4** Serilog in Blazor fixed — `BrowserConsole` sink, dev-only via `appsettings.Development.json`
 - ✅ **#5 (partial)** Scryfall rate limiting fixed (shared `MtgApiFixture`), `BaseTest`/`ApiBaseTest` split, `StreamRoundTripTest` added
+- ✅ **#6** `CardMapFactory.GenerateClassMap` replaced by `GenerateReadMap` / `GenerateWriteMap`; both throw `ArgumentException` with the supported-format list for unknown formats, and `GenerateReadMap` throws `InvalidOperationException` for write-only formats (CARDKINGDOM)
 - ✅ **#10** `File.OpenWrite` → `File.Create` (truncates existing files)
 - ✅ **#11** `FileStream` resource leak in Console — uses string overload now
 - ✅ **#12** Missing `EnsureSuccessStatusCode` in Scryfall token fetch

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_size = 2
 
 # Indentation and spacing
 indent_size = 4
-indent_style = space
+indent_style = tab
 tab_width = 4
 
 # New line preferences

--- a/MtgCsvHelper.Tests/DeckFormatTests.cs
+++ b/MtgCsvHelper.Tests/DeckFormatTests.cs
@@ -11,11 +11,56 @@ public class DeckFormatTests(MtgApiFixture fixture, ITestOutputHelper output) : 
 	[InlineData("MANABOX")]
 	[InlineData("TOPDECKED")]
 	[InlineData("DECKBOX")]
-	//[InlineData("CARDKINGDOM")]
-	public void SupportedTest(string deckFormatName)
+	[InlineData("MTGGOLDFISH")]
+	[InlineData("TCGPLAYER")]
+	public void GenerateReadMap_ForBidirectionalFormats_Succeeds(string deckFormatName)
 	{
-		var classMap = new CardMapFactory(_config, _api).GenerateClassMap(deckFormatName);
-		classMap.Should().NotBeNull();
+		var map = new CardMapFactory(_config, _api).GenerateReadMap(deckFormatName);
+		map.Should().NotBeNull();
+	}
+
+	[Theory]
+	[InlineData("DRAGONSHIELD")]
+	[InlineData("MOXFIELD")]
+	[InlineData("MANABOX")]
+	[InlineData("TOPDECKED")]
+	[InlineData("DECKBOX")]
+	[InlineData("MTGGOLDFISH")]
+	[InlineData("TCGPLAYER")]
+	[InlineData("CARDKINGDOM")]
+	public void GenerateWriteMap_ForAllSupportedFormats_Succeeds(string deckFormatName)
+	{
+		var map = new CardMapFactory(_config, _api).GenerateWriteMap(deckFormatName);
+		map.Should().NotBeNull();
+	}
+
+	[Fact]
+	public void GenerateReadMap_ForCardKingdom_Throws()
+	{
+		var factory = new CardMapFactory(_config, _api);
+		var act = () => factory.GenerateReadMap("CARDKINGDOM");
+		act.Should().Throw<InvalidOperationException>().WithMessage("*write-only*");
+	}
+
+	[Theory]
+	[InlineData("UNKNOWN_FORMAT")]
+	[InlineData("")]
+	public void GenerateReadMap_ForUnknownFormat_ThrowsWithSupportedList(string deckFormatName)
+	{
+		var factory = new CardMapFactory(_config, _api);
+		var act = () => factory.GenerateReadMap(deckFormatName);
+		act.Should().Throw<ArgumentException>()
+			.WithMessage("*MOXFIELD*"); // supported list is included in the message
+	}
+
+	[Theory]
+	[InlineData("UNKNOWN_FORMAT")]
+	public void GenerateWriteMap_ForUnknownFormat_ThrowsWithSupportedList(string deckFormatName)
+	{
+		var factory = new CardMapFactory(_config, _api);
+		var act = () => factory.GenerateWriteMap(deckFormatName);
+		act.Should().Throw<ArgumentException>()
+			.WithMessage("*MOXFIELD*");
 	}
 
 	[Theory]
@@ -41,5 +86,13 @@ public class DeckFormatTests(MtgApiFixture fixture, ITestOutputHelper output) : 
 		parsed.Should().HaveCount(1);
 		parsed[0].Printing.Name.Should().Be("Lightning Bolt");
 		parsed[0].Count.Should().Be(2);
+	}
+
+	[Fact]
+	public void ParseCollectionCsv_WithCardKingdomAsInput_Throws()
+	{
+		var handler = new MtgCardCsvHandler(_api, _config, "CARDKINGDOM");
+		var act = () => handler.ParseCollectionCsv(new MemoryStream("a,b,c\n"u8.ToArray()));
+		act.Should().Throw<InvalidOperationException>().WithMessage("*write-only*");
 	}
 }

--- a/MtgCsvHelper/CardMapFactory.cs
+++ b/MtgCsvHelper/CardMapFactory.cs
@@ -1,3 +1,4 @@
+using CsvHelper.Configuration;
 using Microsoft.Extensions.Configuration;
 using MtgCsvHelper.Maps;
 using MtgCsvHelper.Services;
@@ -6,17 +7,39 @@ namespace MtgCsvHelper;
 
 public class CardMapFactory(IConfiguration config, IMtgApi api)
 {
-	readonly List<DeckConfig> _deckConfigs = From(config).ToList();
+	readonly List<FormatConfig> _formatConfigs = From(config).ToList();
 
 	public static List<string> Supported { get; } = ["MOXFIELD", "DRAGONSHIELD", "MANABOX", "TOPDECKED", "DECKBOX", "CARDKINGDOM", "MTGGOLDFISH", "TCGPLAYER"];
 	public static List<string> NotYetFullySupported { get; } = ["URZAGATHERER"];
 
-	public static IEnumerable<DeckConfig> From(IConfiguration config) =>
+	// Formats that cannot be parsed (their CSV does not carry enough information to recover a canonical card).
+	static readonly HashSet<string> WriteOnlyFormats = new(StringComparer.OrdinalIgnoreCase) { "CARDKINGDOM" };
+
+	public static IEnumerable<FormatConfig> From(IConfiguration config) =>
 		config.GetSection("CsvConfigurations")
 		.GetChildren()
-		.Select(c => c.Get<DeckConfig>()!);
+		.Select(c => c.Get<FormatConfig>()!);
 
-	public DeckConfig? GetDeckConfig(string format) => _deckConfigs.FirstOrDefault(c => c.Name.Equals(format));
+	public FormatConfig? GetFormatConfig(string format) => _formatConfigs.FirstOrDefault(c => c.Name.Equals(format, StringComparison.OrdinalIgnoreCase));
 
-	public PhysicalCardMap? GenerateClassMap(string format) => GetDeckConfig(format) is DeckConfig dc ? new(dc, format.Equals("CARDKINGDOM"), api) : null;
+	public ClassMap<PhysicalMtgCard> GenerateReadMap(string format)
+	{
+		var cfg = RequireFormat(format);
+		if (WriteOnlyFormats.Contains(format))
+		{
+			throw new InvalidOperationException($"Format '{format}' is write-only and cannot be parsed.");
+		}
+		return new PhysicalCardMap(cfg, api);
+	}
+
+	public ClassMap<PhysicalMtgCard> GenerateWriteMap(string format)
+	{
+		var cfg = RequireFormat(format);
+		return format.Equals("CARDKINGDOM", StringComparison.OrdinalIgnoreCase)
+			? new CardKingdomWriteMap(cfg, api)
+			: new PhysicalCardMap(cfg, api);
+	}
+
+	FormatConfig RequireFormat(string format) => GetFormatConfig(format)
+		?? throw new ArgumentException($"Unsupported format '{format}'. Supported: {string.Join(", ", Supported)}.", nameof(format));
 }

--- a/MtgCsvHelper/Converters/CardConditionConverter.cs
+++ b/MtgCsvHelper/Converters/CardConditionConverter.cs
@@ -1,6 +1,5 @@
 ﻿using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
-using MtgCsvHelper.Maps;
 
 namespace MtgCsvHelper.Converters;
 
@@ -21,7 +20,6 @@ public class CardConditionConverter(ConditionConfiguration configuration) : ITyp
 				_ when _conditionConfig.Played.Equals(text)			=> CardCondition.PLAYED,
 				_ when _conditionConfig.Poor.Equals(text)			=> CardCondition.POOR,
 				_													=> CardCondition.UNKNOWN,
-
 			};
 
 		}

--- a/MtgCsvHelper/Converters/CardNameConverter.cs
+++ b/MtgCsvHelper/Converters/CardNameConverter.cs
@@ -1,6 +1,5 @@
 ﻿using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
-using MtgCsvHelper.Maps;
 using MtgCsvHelper.Services;
 
 namespace MtgCsvHelper.Converters;

--- a/MtgCsvHelper/Converters/FinishConverter.cs
+++ b/MtgCsvHelper/Converters/FinishConverter.cs
@@ -1,6 +1,5 @@
 ﻿using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
-using MtgCsvHelper.Maps;
 
 namespace MtgCsvHelper.Converters;
 

--- a/MtgCsvHelper/Converters/LanguageConverter.cs
+++ b/MtgCsvHelper/Converters/LanguageConverter.cs
@@ -1,6 +1,5 @@
 ﻿using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
-using MtgCsvHelper.Maps;
 
 namespace MtgCsvHelper.Converters;
 

--- a/MtgCsvHelper/Converters/PriceConverter.cs
+++ b/MtgCsvHelper/Converters/PriceConverter.cs
@@ -1,6 +1,5 @@
 ﻿using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
-using MtgCsvHelper.Maps;
 
 namespace MtgCsvHelper.Converters;
 

--- a/MtgCsvHelper/FormatConfig.cs
+++ b/MtgCsvHelper/FormatConfig.cs
@@ -1,0 +1,67 @@
+namespace MtgCsvHelper;
+
+public record FormatConfig(
+	string Name,
+	string Quantity,
+	CardNameConfiguration CardName,
+	string? SetNumber = null,
+	string? SetCode = null,
+	string? SetName = null,
+	FinishConfiguration? Finish = null,
+	ConditionConfiguration? Condition = null,
+	LanguageConfiguration? Language = null,
+	PriceConfiguration? PriceBought = null
+	)
+{
+	public Currency Currency => Currency.FromString(PriceBought?.Currency);
+};
+
+// Shared shape for the rich sub-record configurations: all expose the CSV header they bind to.
+// Lets the map base class register them generically without per-type branching.
+public interface IHeaderConfig
+{
+	string HeaderName { get; }
+}
+
+public record CardNameConfiguration(
+	string HeaderName,
+	bool ShortNames = false,
+	bool EncodeToken = false) : IHeaderConfig;
+
+public record FinishConfiguration(
+	string HeaderName,
+	string Foil,
+	string Normal,
+	string? Etched = null) : IHeaderConfig;
+
+public record ConditionConfiguration(
+	string HeaderName,
+	string Mint,
+	string NearMint,
+	string Excellent,
+	string Good,
+	string LightlyPlayed,
+	string Played,
+	string Poor) : IHeaderConfig;
+
+public record LanguageConfiguration(
+	string HeaderName,
+	LanguageMappings Mappings) : IHeaderConfig;
+
+public record LanguageMappings(
+	string en,
+	string es,
+	string fr,
+	string de,
+	string it,
+	string pt,
+	string ja,
+	string ko,
+	string ru,
+	string zht,
+	string zhs);
+
+public record PriceConfiguration(
+	string HeaderName,
+	string Currency,
+	string CurrencySymbol) : IHeaderConfig;

--- a/MtgCsvHelper/Maps/CardKingdomWriteMap.cs
+++ b/MtgCsvHelper/Maps/CardKingdomWriteMap.cs
@@ -1,0 +1,20 @@
+using CsvHelper.Configuration;
+using MtgCsvHelper.Converters;
+using MtgCsvHelper.Services;
+
+namespace MtgCsvHelper.Maps;
+
+// Card Kingdom requires a fixed 4-column shape with uppercase set names.
+// It is a write-only format (their import is buylist-style, no condition/language/foil etched).
+public class CardKingdomWriteMap : ClassMap<PhysicalMtgCard>
+{
+	public CardKingdomWriteMap(FormatConfig columnConfig, IMtgApi api)
+	{
+		_ = columnConfig.Finish ?? throw new InvalidOperationException($"Format '{columnConfig.Name}' is missing the required 'Finish' configuration section.");
+
+		Map(card => card.Printing.Name).TypeConverter(new CardNameConverter(columnConfig.CardName, api)).Name(columnConfig.CardName.HeaderName).Index(0);
+		if (columnConfig.SetName is not null) { Map(card => card.Printing.SetName).TypeConverter<UpperCaseConverter>().Name(columnConfig.SetName).Index(1); }
+		Map(card => card.Foil).TypeConverter(new FinishConverter(columnConfig.Finish)).Name(columnConfig.Finish.HeaderName).Index(2);
+		Map(card => card.Count).Name(columnConfig.Quantity).Index(3);
+	}
+}

--- a/MtgCsvHelper/Maps/PhysicalCardMap.cs
+++ b/MtgCsvHelper/Maps/PhysicalCardMap.cs
@@ -1,101 +1,43 @@
-﻿using CsvHelper.Configuration;
+using System.Linq.Expressions;
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
 using MtgCsvHelper.Converters;
 using MtgCsvHelper.Services;
 
 namespace MtgCsvHelper.Maps;
 
+// Bidirectional map for formats whose read and write shape are identical (every supported format except Card Kingdom).
+// MapOptional hides the "if config is null skip, otherwise Map(...).Name(...).Optional()" boilerplate
+// so the body reads as a flat list of mappings rather than a forest of null checks.
 public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 {
-    public PhysicalCardMap(DeckConfig columnConfig, bool ck, IMtgApi api)
-    {
-        // Yes it is ugly. No I dont care. F#!& you CardKingdom!
-        if (ck)
-        {
-            ConfigureCK(columnConfig, api);
-        }
-        else
-        {
-            ConfigureMaps(columnConfig, api);
-        }
-    }
+	public PhysicalCardMap(FormatConfig cfg, IMtgApi api)
+	{
+		Map(c => c.Count).Name(cfg.Quantity).Index(1);
+		Map(c => c.Printing.Name)
+			.TypeConverter(new CardNameConverter(cfg.CardName, api))
+			.Name(cfg.CardName.HeaderName).Index(0);
 
-    void ConfigureMaps(DeckConfig columnConfig, IMtgApi api)
-    {
-        Map(card => card.Count).Name(columnConfig.Quantity).Index(1);
-        Map(card => card.Printing.Name).TypeConverter(new CardNameConverter(columnConfig.CardName, api)).Name(columnConfig.CardName.HeaderName).Index(0);
-        if (columnConfig.SetNumber is not null) { Map(card => card.Printing.CollectorNumber).Name(columnConfig.SetNumber).Optional(); }
+		// At least one of SetCode / SetName is expected per format (sites differ on which they include).
+		MapOptional(c => c.Printing.CollectorNumber, cfg.SetNumber);
+		MapOptional(c => c.Printing.Set, cfg.SetCode)?.TypeConverter<UpperCaseConverter>();
+		MapOptional(c => c.Printing.SetName, cfg.SetName);
 
-        // We implicitly assume that at least one of them is present (some sites use SetName, some use SetCode, some use both...)
-        if (columnConfig.SetCode is not null) { Map(card => card.Printing.Set).TypeConverter<UpperCaseConverter>().Name(columnConfig.SetCode).Optional(); }
-        if (columnConfig.SetName is not null) { Map(card => card.Printing.SetName).Name(columnConfig.SetName).Optional(); }
+		MapOptional(c => c.Condition, cfg.Condition, c => new CardConditionConverter(c));
+		MapOptional(c => c.Foil, cfg.Finish, c => new FinishConverter(c));
+		MapOptional(c => c.Language, cfg.Language, c => new LanguageConverter(c));
+		MapOptional(c => c.PriceBought, cfg.PriceBought, c => new PriceConverter(c));
+	}
 
-        if (columnConfig.Condition is ConditionConfiguration cond) { Map(card => card.Condition).TypeConverter(new CardConditionConverter(cond)).Name(cond.HeaderName).Optional(); }
-        if (columnConfig.Finish is FinishConfiguration finish) { Map(card => card.Foil).TypeConverter(new FinishConverter(finish)).Name(finish.HeaderName).Optional(); }
-        if (columnConfig.Language is LanguageConfiguration lang) { Map(card => card.Language).TypeConverter(new LanguageConverter(lang)).Name(lang.HeaderName).Optional(); }
-        if (columnConfig.PriceBought is PriceConfiguration price) { Map(card => card.PriceBought).TypeConverter(new PriceConverter(price)).Name(price.HeaderName).Optional(); }
-    }
+	MemberMap<PhysicalMtgCard, TMember>? MapOptional<TMember>(
+		Expression<Func<PhysicalMtgCard, TMember?>> property,
+		string? headerName)
+		=> headerName is null ? null : Map(property).Name(headerName).Optional();
 
-    void ConfigureCK(DeckConfig columnConfig, IMtgApi api)
-    {
-        Map(card => card.Printing.Name).TypeConverter(new CardNameConverter(columnConfig.CardName, api)).Name(columnConfig.CardName.HeaderName).Index(0);
-        if (columnConfig.SetName is not null) { Map(card => card.Printing.SetName).TypeConverter<UpperCaseConverter>().Name(columnConfig.SetName).Index(1); }
-        Map(card => card.Foil).TypeConverter(new FinishConverter(columnConfig.Finish!)).Name(columnConfig.Finish!.HeaderName).Index(2);
-        Map(card => card.Count).Name(columnConfig.Quantity).Index(3);
-    }
+	MemberMap<PhysicalMtgCard, TMember>? MapOptional<TMember, TConfig>(
+		Expression<Func<PhysicalMtgCard, TMember?>> property,
+		TConfig? config,
+		Func<TConfig, ITypeConverter> converterFactory)
+		where TConfig : class, IHeaderConfig
+		=> config is null ? null : Map(property).TypeConverter(converterFactory(config)).Name(config.HeaderName).Optional();
 }
-
-public record DeckConfig(
-    string Name,
-    string Quantity,
-    CardNameConfiguration CardName,
-    string? SetNumber = null,
-    string? SetCode = null,
-    string? SetName = null,
-    FinishConfiguration? Finish = null,
-    ConditionConfiguration? Condition = null,
-    LanguageConfiguration? Language = null,
-    PriceConfiguration? PriceBought = null
-    )
-{
-    public Currency Currency => Currency.FromString(PriceBought?.Currency);
-};
-
-public record CardNameConfiguration(
-    string HeaderName,
-    bool ShortNames = false,
-    bool EncodeToken = false);
-public record FinishConfiguration(
-    string HeaderName,
-    string Foil,
-    string Normal,
-    string? Etched = null);
-public record ConditionConfiguration(
-    string HeaderName,
-    string Mint,
-    string NearMint,
-    string Excellent,
-    string Good,
-    string LightlyPlayed,
-    string Played,
-    string Poor);
-public record LanguageConfiguration(
-    string HeaderName,
-    LanguageMappings Mappings);
-public record LanguageMappings(
-    string en,
-    string es,
-    string fr,
-    string de,
-    string it,
-    string pt,
-    string ja,
-    string ko,
-    string ru,
-    string zht,
-    string zhs
-    );
-
-public record PriceConfiguration(
-    string HeaderName,
-    string Currency,
-    string CurrencySymbol);

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -1,20 +1,19 @@
-﻿using System.Globalization;
+using System.Globalization;
 using CsvHelper.Configuration;
 using Microsoft.Extensions.Configuration;
-using MtgCsvHelper.Maps;
 using MtgCsvHelper.Services;
 
 namespace MtgCsvHelper;
 public class MtgCardCsvHandler
 {
-	readonly PhysicalCardMap _classMap;
+	readonly CardMapFactory _factory;
 	readonly IMtgApi _api;
 	readonly string _format;
 
 	public MtgCardCsvHandler(IMtgApi api, IConfiguration config, string format)
 	{
 		_format = format;
-		_classMap = new CardMapFactory(config, api).GenerateClassMap(format) ?? throw new ArgumentException($"Unsupported {format} - not found in configuration file");
+		_factory = new CardMapFactory(config, api);
 		_api = api;
 	}
 
@@ -27,7 +26,7 @@ public class MtgCardCsvHandler
 		CheckIfFirstLineCanBeIgnored(stream);
 
 		using var csv = new CsvReader(stream, new CsvConfiguration(CultureInfo.InvariantCulture) {/* HeaderValidated = null,*/ MissingFieldFound = null });
-		csv.Context.RegisterClassMap(_classMap);
+		csv.Context.RegisterClassMap(_factory.GenerateReadMap(_format));
 		List<PhysicalMtgCard> cards = csv.GetRecords<PhysicalMtgCard>().ToList();
 
 		var sets = _api.GetSets();
@@ -70,7 +69,7 @@ public class MtgCardCsvHandler
 		using var writer = new StreamWriter(outputStream, leaveOpen: true);
 		using var csv = new CsvWriter(writer, CultureInfo.InvariantCulture);
 
-		csv.Context.RegisterClassMap(_classMap);
+		csv.Context.RegisterClassMap(_factory.GenerateWriteMap(_format));
 		csv.WriteHeader<PhysicalMtgCard>();
 		csv.NextRecord();
 		csv.WriteRecords(cards);


### PR DESCRIPTION
## Summary

Cleans up the `bool ck` smell in `PhysicalCardMap` by splitting the factory along the read/write axis. Groundwork for #39 (Cardmarket support); also resolves [finding #6](https://github.com/StepKie/MtgCsvHelper/blob/develop/.claude/findings.md).

## What changed

- **`CardMapFactory`**: replaced `GenerateClassMap(format)` with `GenerateReadMap(format)` / `GenerateWriteMap(format)`. Throws `ArgumentException` listing supported formats for unknown formats. Throws `InvalidOperationException` for `CARDKINGDOM` as input (the only write-only format today).
- **Map classes**: `PhysicalCardMap` is now bidirectional and shared by every format whose row shape is symmetric. CK keeps its own `CardKingdomWriteMap` because its column shape is genuinely different (4 columns, fixed indices, uppercase set name).
- **`MtgCardCsvHandler`**: lazy-loads the right map per direction. CK-as-input fails fast at parse time with a clear "write-only" message.
- **Boilerplate cleanup**: introduced `IHeaderConfig` interface and `MapOptional` helpers in `PhysicalCardMap` to replace the `if (cfg.X is not null) Map(...).Optional()` chain. The mapping body now reads as a flat list.
- **Rename**: `DeckConfig` → `FormatConfig` (moved into its own file). The records describe a CSV format, not a deck.
- **Style**: `.editorconfig` was set to `indent_style = space`, but the code actually uses tabs everywhere. Updated to `tab` to match reality (existing files don't change).

## Why no per-format read/write subclasses?

The split lives at the **factory level**, not in the class hierarchy. A new map class is only justified when the row *shape* differs (which columns exist, in what order). Per-format value normalization (header names, foil/condition encodings, language codes) lives in `appsettings.json` and converters — that's the right seam, and adding subclasses for value-level differences would be premature abstraction.

When #39 (Cardmarket) lands, it'll need a `CardmarketReadMap` because its rows are structurally different (single `cardmarket_id`, no name/set/collector-number columns). That's where a new map class earns its keep.

## Test plan

- [x] `dotnet build`: 0 warnings, 0 errors
- [x] `dotnet test`: 62/62 passing
- [x] New tests cover: read-direction routing, write-direction routing including CK, `GenerateReadMap("CARDKINGDOM")` throws, unknown format throws with supported list, and `ParseCollectionCsv` on a CK handler throws