### PR TITLE
Fault-tolerant import: per-row try/catch, warnings, structured ParseResult

### DIFF
--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -4,6 +4,7 @@
 @inject IJSRuntime JS
 @using Serilog
 @using System.Text
+@using CsvHelper
 @implements IDisposable
 
 <h3 class="mb-4">Convert your MtG collection .csv file</h3>
@@ -67,6 +68,10 @@
 			{
 				<button class="btn btn-success" @onclick="DownloadResult">Download Converted .csv</button>
 			}
+			@if (!_isConverting && _issues.Any(i => i.Severity == IssueSeverity.Error))
+			{
+				<button class="btn btn-warning ms-2" @onclick="DownloadErrorCsv">Download Error Report .csv</button>
+			}
 		</div>
 	</div>
 </div>
@@ -79,15 +84,37 @@
 	</div>
 }
 
+@if (!string.IsNullOrEmpty(_headerError))
+{
+	<div class="alert alert-danger mt-3" role="alert">
+		@_headerError
+	</div>
+}
+
 @if (!string.IsNullOrEmpty(_summary))
 {
-	<p style="white-space: pre-line" >@_summary</p>
+	<p style="white-space: pre-line">@_summary</p>
+}
+
+@if (_issues.Any())
+{
+	var errorCount = _issues.Count(i => i.Severity == IssueSeverity.Error);
+	var warningCount = _issues.Count(i => i.Severity == IssueSeverity.Warning);
+	<h4>Import Issues — @errorCount errors, @warningCount warnings</h4>
+	<ul>
+		@foreach (var issue in _issues)
+		{
+			var label = issue.Severity == IssueSeverity.Error ? "text-danger" : "text-warning";
+			<li class="@label">
+				<strong>[@issue.Severity]</strong> row @issue.RowNumber@(issue.CardName is not null ? $" ({issue.CardName})" : ""): @issue.Reason
+			</li>
+		}
+	</ul>
 }
 
 @if (_processedRecords.Any())
 {
 	<h4>Processed Records</h4>
-	<!-- Display the processed records as needed -->
 	<ul>
 		@foreach (var record in _processedRecords)
 		{
@@ -104,9 +131,11 @@
 	private string _selectedOutputFormat = _supportedFormats[1];
 
 	private List<string> _processedRecords = [];
+	private List<ImportIssue> _issues = [];
 	private IBrowserFile? _csvFile;
 
 	private string? _summary;
+	private string? _headerError;
 	private bool _isConverting;
 	private bool _isApiLoading = true;
 	private string? _resultFileName;
@@ -131,6 +160,13 @@
 		try
 		{
 			_isConverting = true;
+			_summary = null;
+			_headerError = null;
+			_issues = [];
+			_processedRecords = [];
+			_resultStream?.Dispose();
+			_resultStream = null;
+			_resultFileName = null;
 			StateHasChanged();
 			await Task.Delay(1);
 
@@ -141,15 +177,24 @@
 			var reader = new MtgCardCsvHandler(Api, Config, _selectedInputFormat);
 			var writer = new MtgCardCsvHandler(Api, Config, _selectedOutputFormat);
 
-			var collection = reader.ParseCollectionCsv(csvStream);
-			_summary = collection.GenerateSummary();
+			var result = reader.ParseCollectionCsv(csvStream);
+			_summary = result.Collection.GenerateSummary();
+			_issues = result.Issues.ToList();
 
-			var cards = collection.Cards;
+			var cards = result.Collection.Cards;
 			_processedRecords = cards.Select(c => c.Printing.Name).ToList();
-			_resultFileName = $"{_selectedInputFormat}-to-{_selectedOutputFormat}_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv";
-			_resultStream?.Dispose();
-			_resultStream = new MemoryStream();
-			writer.WriteCollectionCsv(cards, _resultStream);
+
+			if (cards.Count > 0)
+			{
+				_resultFileName = $"{_selectedInputFormat}-to-{_selectedOutputFormat}_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv";
+				_resultStream = new MemoryStream();
+				writer.WriteCollectionCsv(cards, _resultStream);
+			}
+		}
+		catch (HeaderValidationException hex)
+		{
+			var missing = hex.InvalidHeaders.SelectMany(h => h.Names).Distinct().ToList();
+			_headerError = $"This doesn't look like a valid {_selectedInputFormat} CSV — missing required column(s): {string.Join(", ", missing)}. Did you select the correct input format?";
 		}
 		catch (Exception ex)
 		{
@@ -173,6 +218,26 @@
 		_resultStream.Position = 0;
 		using var streamRef = new DotNetStreamReference(stream: _resultStream, leaveOpen: true);
 		await JS.InvokeVoidAsync("downloadFileFromStream", _resultFileName, streamRef);
+	}
+
+	private async Task DownloadErrorCsv()
+	{
+		var errors = _issues.Where(i => i.Severity == IssueSeverity.Error).ToList();
+		if (errors.Count == 0) return;
+
+		var sb = new StringBuilder();
+		sb.AppendLine("RowNumber,RawContent,Reason");
+		foreach (var e in errors)
+		{
+			sb.AppendLine($"{e.RowNumber},{Csv(e.RawContent)},{Csv(e.Reason)}");
+		}
+
+		var bytes = Encoding.UTF8.GetBytes(sb.ToString());
+		using var stream = new MemoryStream(bytes);
+		using var streamRef = new DotNetStreamReference(stream, leaveOpen: false);
+		await JS.InvokeVoidAsync("downloadFileFromStream", $"{_selectedInputFormat}-import-errors-{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv", streamRef);
+
+		static string Csv(string? value) => value is null ? "" : $"\"{value.Replace("\"", "\"\"")}\"";
 	}
 
 	public void Dispose()

--- a/MtgCsvHelper.Console/Program.cs
+++ b/MtgCsvHelper.Console/Program.cs
@@ -1,4 +1,5 @@
 ﻿using CommandLine;
+using CsvHelper;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -36,8 +37,30 @@ void RunWithOptions(CommandLineOptions opts)
 
 	foreach (var fileName in filesToParse)
 	{
-		var parsedCardsFromFile = reader.ParseCollectionCsv(fileName).Cards;
-		cardsFound.AddRange(parsedCardsFromFile);
+		try
+		{
+			var result = reader.ParseCollectionCsv(fileName);
+			cardsFound.AddRange(result.Collection.Cards);
+			if (result.ErrorCount > 0 || result.WarningCount > 0)
+			{
+				Log.Information($"{fileName}: {result.Collection.Cards.Count} cards parsed, {result.ErrorCount} errors, {result.WarningCount} warnings");
+				foreach (var issue in result.Issues)
+				{
+					Log.Warning($"  [{issue.Severity}] row {issue.RowNumber}: {issue.Reason}");
+				}
+			}
+		}
+		catch (HeaderValidationException ex)
+		{
+			var missing = ex.InvalidHeaders.SelectMany(h => h.Names).Distinct().ToList();
+			Log.Error($"{fileName}: header mismatch — missing required column(s): {string.Join(", ", missing)}. Did you select the correct input format ({opts.InputFormat})?");
+		}
+	}
+
+	if (cardsFound.Count == 0)
+	{
+		Log.Warning("No cards parsed from any input file - skipping output write.");
+		return;
 	}
 
 	writer.WriteCollectionCsv(cardsFound);

--- a/MtgCsvHelper.Tests/DeckFormatTests.cs
+++ b/MtgCsvHelper.Tests/DeckFormatTests.cs
@@ -81,7 +81,7 @@ public class DeckFormatTests(MtgApiFixture fixture, ITestOutputHelper output) : 
 		handler.WriteCollectionCsv(original, stream);
 		stream.Position = 0;
 
-		var parsed = handler.ParseCollectionCsv(stream).Cards;
+		var parsed = handler.ParseCollectionCsv(stream).Collection.Cards;
 
 		parsed.Should().HaveCount(1);
 		parsed[0].Printing.Name.Should().Be("Lightning Bolt");

--- a/MtgCsvHelper.Tests/FaultToleranceTests.cs
+++ b/MtgCsvHelper.Tests/FaultToleranceTests.cs
@@ -1,0 +1,116 @@
+using System.Text;
+using CsvHelper;
+
+namespace MtgCsvHelper.Tests;
+
+[Collection(MtgApiCollection.Name)]
+public class FaultToleranceTests(MtgApiFixture fixture, ITestOutputHelper output) : ApiBaseTest(fixture, output)
+{
+	const string MoxHeader = "Count,Name,Edition,Collector Number,Foil,Condition,Language,Purchase Price";
+
+	static MemoryStream CsvStream(string csv) => new(Encoding.UTF8.GetBytes(csv));
+	MtgCardCsvHandler Handler(string format = "MOXFIELD") => new(_api, _config, format);
+
+	[Fact]
+	public void HappyPath_AllValid_ProducesCardsAndNoIssues()
+	{
+		var csv = MoxHeader + "\n"
+			+ "2,Lightning Bolt,M11,149,,Near Mint,English,\n"
+			+ "1,Counterspell,MMQ,69,,Near Mint,English,\n";
+
+		var result = Handler().ParseCollectionCsv(CsvStream(csv));
+
+		result.Collection.Cards.Should().HaveCount(2);
+		result.Issues.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Invariant_MixedValidAndInvalidRows_CardCountPlusErrorCountEqualsDataRows()
+	{
+		const int dataRows = 3;
+		var csv = MoxHeader + "\n"
+			+ "2,Lightning Bolt,M11,149,,Near Mint,English,\n"
+			+ "notanint,Counterspell,MMQ,69,,Near Mint,English,\n" // bad Count → error
+			+ "1,Mox Ruby,LEA,265,,Near Mint,English,\n";
+
+		var result = Handler().ParseCollectionCsv(CsvStream(csv));
+
+		result.Collection.Cards.Should().HaveCount(2);
+		result.ErrorCount.Should().Be(1);
+		(result.Collection.Cards.Count + result.ErrorCount).Should().Be(dataRows);
+	}
+
+	[Fact]
+	public void AllRowsInvalid_NoCardsAllErrors()
+	{
+		var csv = MoxHeader + "\n"
+			+ "notanint,A,M11,149,,Near Mint,English,\n"
+			+ "alsobad,B,M11,149,,Near Mint,English,\n";
+
+		var result = Handler().ParseCollectionCsv(CsvStream(csv));
+
+		result.Collection.Cards.Should().BeEmpty();
+		result.ErrorCount.Should().Be(2);
+		result.Issues.Should().AllSatisfy(i => i.Severity.Should().Be(IssueSeverity.Error));
+	}
+
+	[Fact]
+	public void UnknownSetCode_RaisesWarning_CardStillImported()
+	{
+		// "FAKESET" is not a real Scryfall set code — post-load enrichment will fail to backfill the set name.
+		var csv = MoxHeader + "\n"
+			+ "1,Lightning Bolt,FAKESET,149,,Near Mint,English,\n";
+
+		var result = Handler().ParseCollectionCsv(CsvStream(csv));
+
+		result.Collection.Cards.Should().HaveCount(1);
+		result.ErrorCount.Should().Be(0);
+		result.WarningCount.Should().Be(1);
+		result.Issues[0].Severity.Should().Be(IssueSeverity.Warning);
+		result.Issues[0].Reason.Should().Contain("FAKESET");
+	}
+
+	[Fact]
+	public void MixedWarningsAndErrors_InvariantHolds()
+	{
+		const int dataRows = 3;
+		var csv = MoxHeader + "\n"
+			+ "1,Lightning Bolt,M11,149,,Near Mint,English,\n"          // valid, no warning
+			+ "1,Lightning Bolt,FAKESET,149,,Near Mint,English,\n"      // valid card, warning (bad set)
+			+ "notanint,Lightning Bolt,M11,149,,Near Mint,English,\n";  // error (bad Count)
+
+		var result = Handler().ParseCollectionCsv(CsvStream(csv));
+
+		result.Collection.Cards.Should().HaveCount(2);
+		result.ErrorCount.Should().Be(1);
+		result.WarningCount.Should().Be(1);
+		(result.Collection.Cards.Count + result.ErrorCount).Should().Be(dataRows);
+	}
+
+	[Fact]
+	public void HeaderMismatch_ThrowsHeaderValidationException_ListingMissingHeaders()
+	{
+		var csv = "wrong,headers,here\n1,2,3\n";
+
+		var act = () => Handler().ParseCollectionCsv(CsvStream(csv));
+
+		var ex = act.Should().Throw<HeaderValidationException>().Which;
+		var missing = ex.InvalidHeaders.SelectMany(h => h.Names).ToList();
+		missing.Should().Contain("Name").And.Contain("Count");
+	}
+
+	[Fact]
+	public void BlankAndDelimiterOnlyRows_SkippedSilently()
+	{
+		var csv = MoxHeader + "\n"
+			+ "2,Lightning Bolt,M11,149,,Near Mint,English,\n"
+			+ "\n"                             // truly blank line
+			+ ",,,,,,,\n"                      // delimiter-only row (should also be skipped)
+			+ "1,Counterspell,MMQ,69,,Near Mint,English,\n";
+
+		var result = Handler().ParseCollectionCsv(CsvStream(csv));
+
+		result.Collection.Cards.Should().HaveCount(2);
+		result.Issues.Should().BeEmpty();
+	}
+}

--- a/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
+++ b/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
@@ -24,7 +24,7 @@ public class MtgCardCsvHandlerTests(MtgApiFixture fixture, ITestOutputHelper out
 		// Act
 		string fileName = $"unittest-{deckFormatName}.csv";
 		handler.WriteCollectionCsv(originalCards, fileName);
-		List<PhysicalMtgCard> parsedCards = handler.ParseCollectionCsv(fileName).Cards;
+		List<PhysicalMtgCard> parsedCards = handler.ParseCollectionCsv(fileName).Collection.Cards;
 
 		// Assert
 		parsedCards.Should().BeEquivalentTo(originalCards);
@@ -43,7 +43,7 @@ public class MtgCardCsvHandlerTests(MtgApiFixture fixture, ITestOutputHelper out
 		IList<PhysicalMtgCard> expectedCards = GetReferenceCards(Currency.FromString(currency));
 
 		// Act
-		IList<PhysicalMtgCard> cards = handler.ParseCollectionCsv(csvFilePath).Cards;
+		IList<PhysicalMtgCard> cards = handler.ParseCollectionCsv(csvFilePath).Collection.Cards;
 
 		// Assert
 		cards.Should().BeEquivalentTo(expectedCards);
@@ -65,12 +65,12 @@ public class MtgCardCsvHandlerTests(MtgApiFixture fixture, ITestOutputHelper out
 		MtgCardCsvHandler handlerIn = CreateHandler(deckFormatIn);
 		MtgCardCsvHandler handlerOut = CreateHandler(deckFormatOut);
 
-		var collection = handlerIn.ParseCollectionCsv(csvFilePath);
-		var cards = collection.Cards;
+		var result = handlerIn.ParseCollectionCsv(csvFilePath);
+		var cards = result.Collection.Cards;
 		var resultFileName = $"unittest_{deckFormatIn}-to-{deckFormatOut}_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv";
 		handlerOut.WriteCollectionCsv(cards, resultFileName);
 
-		Log.Information(collection.GenerateSummary());
+		Log.Information(result.Collection.GenerateSummary());
 		cards.Should().HaveCountGreaterThan(500);
 	}
 

--- a/MtgCsvHelper/Models/ImportIssue.cs
+++ b/MtgCsvHelper/Models/ImportIssue.cs
@@ -1,0 +1,16 @@
+namespace MtgCsvHelper.Models;
+
+public enum IssueSeverity
+{
+	Warning,
+	Error
+}
+
+// Issue surfaced while parsing a CSV. Errors mean the row was skipped (data lost);
+// warnings mean the card was imported but with degraded fidelity (e.g. set lookup miss).
+public record ImportIssue(
+	IssueSeverity Severity,
+	int RowNumber,
+	string Reason,
+	string? CardName = null,
+	string? RawContent = null);

--- a/MtgCsvHelper/Models/ParseResult.cs
+++ b/MtgCsvHelper/Models/ParseResult.cs
@@ -1,0 +1,9 @@
+namespace MtgCsvHelper.Models;
+
+// Result of parsing a CSV: the resulting Collection plus any per-row issues collected.
+// Invariant: cards.Count + ErrorCount == data rows in the CSV (excluding empty/blank lines).
+public record ParseResult(Collection Collection, IReadOnlyList<ImportIssue> Issues)
+{
+	public int ErrorCount => Issues.Count(i => i.Severity == IssueSeverity.Error);
+	public int WarningCount => Issues.Count(i => i.Severity == IssueSeverity.Warning);
+}

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
 using Microsoft.Extensions.Configuration;
 using MtgCsvHelper.Services;
 
@@ -17,31 +18,67 @@ public class MtgCardCsvHandler
 		_api = api;
 	}
 
-	public Collection ParseCollectionCsv(string csvFilePath) => ParseCollectionCsv(File.OpenRead(csvFilePath));
+	public ParseResult ParseCollectionCsv(string csvFilePath) => ParseCollectionCsv(File.OpenRead(csvFilePath));
 
-	public Collection ParseCollectionCsv(Stream csvFilePath)
+	public ParseResult ParseCollectionCsv(Stream csvStream)
 	{
-		Log.Information($"Parsing {csvFilePath} with input format {_format} ...");
-		using var stream = new StreamReader(csvFilePath);
-		CheckIfFirstLineCanBeIgnored(stream);
+		Log.Information($"Parsing input format {_format} ...");
+		using var reader = new StreamReader(csvStream);
+		CheckIfFirstLineCanBeIgnored(reader);
 
-		using var csv = new CsvReader(stream, new CsvConfiguration(CultureInfo.InvariantCulture) {/* HeaderValidated = null,*/ MissingFieldFound = null });
+		using var csv = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture) { MissingFieldFound = null });
 		csv.Context.RegisterClassMap(_factory.GenerateReadMap(_format));
-		List<PhysicalMtgCard> cards = csv.GetRecords<PhysicalMtgCard>().ToList();
 
+		if (!csv.Read())
+		{
+			// Empty file — no header, no rows. Return empty result rather than treating as an error.
+			return new ParseResult(new Collection { Name = $"Import {_format}, Date: {DateTime.Now}", Cards = [] }, []);
+		}
+		csv.ReadHeader();
+		csv.ValidateHeader<PhysicalMtgCard>(); // throws HeaderValidationException if non-Optional fields are missing
+
+		var cards = new List<PhysicalMtgCard>();
+		var issues = new List<ImportIssue>();
 		var sets = _api.GetSets();
 
-		foreach (var card in cards)
+		while (csv.Read())
 		{
-			var logicalCard = card.Printing;
-			logicalCard.SetName ??= sets.FirstOrDefault(s => s.Code.Equals(logicalCard.Set, StringComparison.OrdinalIgnoreCase))?.Name;
-			logicalCard.Set ??= sets.FirstOrDefault(s => s.Name.Equals(logicalCard.SetName, StringComparison.OrdinalIgnoreCase))?.Code.ToUpper();
+			// Skip rows that are blank or contain only delimiters/whitespace.
+			if (csv.Parser.Record is null || csv.Parser.Record.All(string.IsNullOrWhiteSpace))
+			{
+				continue;
+			}
+
+			int rowNum = csv.Parser.Row;
+			try
+			{
+				var card = csv.GetRecord<PhysicalMtgCard>();
+				EnrichSetInfo(card, sets, issues, rowNum);
+				cards.Add(card);
+			}
+			catch (TypeConverterException tcex)
+			{
+				var memberName = tcex.MemberMapData?.Member?.Name ?? "?";
+				var value = tcex.Text ?? "";
+				issues.Add(new ImportIssue(
+					IssueSeverity.Error,
+					rowNum,
+					$"Invalid value '{value}' for column '{memberName}'",
+					RawContent: csv.Parser.RawRecord?.TrimEnd()));
+			}
+			catch (Exception ex)
+			{
+				issues.Add(new ImportIssue(
+					IssueSeverity.Error,
+					rowNum,
+					ex.Message,
+					RawContent: csv.Parser.RawRecord?.TrimEnd()));
+			}
 		}
 
-		Collection collection = new() { Name = $"Import {_format}, Date: {DateTime.Now}", Cards = cards };
+		var collection = new Collection { Name = $"Import {_format}, Date: {DateTime.Now}", Cards = cards };
 		Log.Debug(collection.GenerateSummary());
-
-		return collection;
+		return new ParseResult(collection, issues);
 
 		static void CheckIfFirstLineCanBeIgnored(StreamReader stream)
 		{
@@ -53,6 +90,29 @@ public class MtgCardCsvHandler
 				stream.BaseStream.Position = 0;
 				stream.DiscardBufferedData();
 			}
+		}
+	}
+
+	static void EnrichSetInfo(PhysicalMtgCard card, IEnumerable<ScryfallApi.Client.Models.Set> sets, List<ImportIssue> issues, int rowNum)
+	{
+		var p = card.Printing;
+		bool hadSetCode = p.Set is not null;
+		bool hadSetName = p.SetName is not null;
+
+		p.SetName ??= sets.FirstOrDefault(s => s.Code.Equals(p.Set, StringComparison.OrdinalIgnoreCase))?.Name;
+		p.Set ??= sets.FirstOrDefault(s => s.Name.Equals(p.SetName, StringComparison.OrdinalIgnoreCase))?.Code.ToUpper();
+
+		if (!hadSetCode && !hadSetName)
+		{
+			issues.Add(new ImportIssue(IssueSeverity.Warning, rowNum, "No set information found in row", CardName: p.Name));
+		}
+		else if (hadSetCode && p.SetName is null)
+		{
+			issues.Add(new ImportIssue(IssueSeverity.Warning, rowNum, $"Set code '{p.Set}' not found in Scryfall data", CardName: p.Name));
+		}
+		else if (hadSetName && p.Set is null)
+		{
+			issues.Add(new ImportIssue(IssueSeverity.Warning, rowNum, $"Set name '{p.SetName}' not found in Scryfall data", CardName: p.Name));
 		}
 	}
 

--- a/samples/fault-tolerance/01-happy-path.csv
+++ b/samples/fault-tolerance/01-happy-path.csv
@@ -1,0 +1,4 @@
+Count,Name,Edition,Collector Number,Foil,Condition,Language,Purchase Price
+2,Lightning Bolt,M11,149,,Near Mint,English,
+1,Sol Ring,C19,233,,Near Mint,English,
+3,Counterspell,MH2,267,,Near Mint,English,

--- a/samples/fault-tolerance/02-mixed-valid-invalid.csv
+++ b/samples/fault-tolerance/02-mixed-valid-invalid.csv
@@ -1,0 +1,5 @@
+Count,Name,Edition,Collector Number,Foil,Condition,Language,Purchase Price
+2,Lightning Bolt,M11,149,,Near Mint,English,
+notanumber,Sol Ring,C19,233,,Near Mint,English,
+1,Counterspell,MH2,267,,Near Mint,English,
+oops,Brainstorm,M11,73,,Near Mint,English,

--- a/samples/fault-tolerance/03-all-invalid.csv
+++ b/samples/fault-tolerance/03-all-invalid.csv
@@ -1,0 +1,4 @@
+Count,Name,Edition,Collector Number,Foil,Condition,Language,Purchase Price
+bad,Lightning Bolt,M11,149,,Near Mint,English,
+broken,Sol Ring,C19,233,,Near Mint,English,
+nope,Counterspell,MH2,267,,Near Mint,English,

--- a/samples/fault-tolerance/04-warnings-only.csv
+++ b/samples/fault-tolerance/04-warnings-only.csv
@@ -1,0 +1,4 @@
+Count,Name,Edition,Collector Number,Foil,Condition,Language,Purchase Price
+2,Lightning Bolt,FAKESET1,149,,Near Mint,English,
+1,Sol Ring,FAKESET2,233,,Near Mint,English,
+3,Counterspell,FAKESET3,50,,Near Mint,English,

--- a/samples/fault-tolerance/05-mixed-warnings-errors.csv
+++ b/samples/fault-tolerance/05-mixed-warnings-errors.csv
@@ -1,0 +1,5 @@
+Count,Name,Edition,Collector Number,Foil,Condition,Language,Purchase Price
+2,Lightning Bolt,M11,149,,Near Mint,English,
+1,Sol Ring,FAKESET,233,,Near Mint,English,
+notanumber,Counterspell,MH2,267,,Near Mint,English,
+3,Brainstorm,FAKESET2,50,,Near Mint,English,

--- a/samples/fault-tolerance/06-wrong-format-dragonshield-as-moxfield.csv
+++ b/samples/fault-tolerance/06-wrong-format-dragonshield-as-moxfield.csv
@@ -1,0 +1,3 @@
+Folder Name,Quantity,Trade Quantity,Card Name,Set Code,Set Name,Card Number,Condition,Printing,Language,Price Bought,Date Bought,LOW,MID,MARKET
+Pile Of Stuff,1,0,Lightning Bolt,M11,Magic 2011,149,NearMint,Normal,English,0.50,2024-01-01,0.40,0.50,0.55
+Pile Of Stuff,2,0,Sol Ring,C19,Commander 2019,233,NearMint,Normal,English,1.20,2024-01-01,1.00,1.20,1.30

--- a/samples/fault-tolerance/07-blank-and-delimiter-only-rows.csv
+++ b/samples/fault-tolerance/07-blank-and-delimiter-only-rows.csv
@@ -1,0 +1,6 @@
+Count,Name,Edition,Collector Number,Foil,Condition,Language,Purchase Price
+2,Lightning Bolt,M11,149,,Near Mint,English,
+
+,,,,,,,
+1,Counterspell,MH2,267,,Near Mint,English,
+

--- a/samples/fault-tolerance/README.md
+++ b/samples/fault-tolerance/README.md
@@ -1,0 +1,39 @@
+# Fault-Tolerance Sample CSVs
+
+Hand-crafted Moxfield-format CSVs that exercise each branch of the new fault-tolerant import path. Use them to eyeball Console + Blazor behavior end-to-end before merging #40.
+
+All files are intended to be loaded with **input format `MOXFIELD`** (except #6, which deliberately mismatches).
+
+## Files
+
+| File | What it tests | Expected result |
+|---|---|---|
+| `01-happy-path.csv` | All valid rows, real Scryfall set codes | 3 cards, 0 errors, 0 warnings |
+| `02-mixed-valid-invalid.csv` | Valid rows interspersed with rows whose `Count` cell is non-numeric | 2 cards, 2 errors |
+| `03-all-invalid.csv` | Every row has a non-numeric `Count` | 0 cards, 3 errors |
+| `04-warnings-only.csv` | Valid rows but with set codes not in Scryfall (`FAKESET1` etc.) | 3 cards, 0 errors, 3 warnings |
+| `05-mixed-warnings-errors.csv` | One valid + one warning + one error + one warning | 3 cards, 1 error, 2 warnings (invariant: `cards + errors == 4`) |
+| `06-wrong-format-dragonshield-as-moxfield.csv` | A DragonShield-shaped CSV — when imported as MOXFIELD, the required `Count`/`Name` headers are missing | `HeaderValidationException` thrown — Blazor surfaces a red header-error alert; Console aborts |
+| `07-blank-and-delimiter-only-rows.csv` | Two valid rows interleaved with a truly blank line and a `,,,,,,,` line | 2 cards, 0 errors, 0 warnings |
+
+## Running locally
+
+### Blazor (recommended for visual verification)
+
+```bash
+dotnet run --project MtgCsvHelper.BlazorWebAssembly
+```
+
+Open the printed URL, pick `MOXFIELD` as input format, upload one of the CSVs, click **Convert**, observe:
+- the issues list (severity-coloured)
+- the **Download Error Report .csv** button (only when errors > 0)
+- the red header-error alert (only for file #6)
+
+### Console
+
+```bash
+# from a directory containing the sample CSV(s):
+dotnet run --project /path/to/MtgCsvHelper.Console -- --in MOXFIELD --out MANABOX -f 02-mixed-valid-invalid.csv
+```
+
+The console logs `{file}: N cards parsed, M errors, K warnings` followed by one line per issue.


### PR DESCRIPTION
Closes #40.

## Summary

Resolves the all-or-nothing import failure mode: a single bad row no longer aborts the whole conversion, and silent degradations (set-name lookup misses) are now surfaced as warnings instead of producing empty fields without notice.

## What changed

### New types ([MtgCsvHelper/Models/](https://github.com/StepKie/MtgCsvHelper/blob/feature/40-fault-tolerance/MtgCsvHelper/Models/))
- `ParseResult { Collection, IReadOnlyList<ImportIssue> }` — return type of `ParseCollectionCsv`.
- `ImportIssue { Severity, RowNumber, Reason, CardName?, RawContent? }` — `Severity = Error|Warning`. Errors mean the row was skipped (data lost); warnings mean the card was imported but with degraded fidelity (set-name lookup miss, etc.).

### Handler (`MtgCardCsvHandler.ParseCollectionCsv`)
- Header validation delegated to CsvHelper's built-in `HeaderValidationException` — required headers come from the registered class map (any field not marked `.Optional()` must be present). No custom comparison.
- Per-row try/catch in a manual `csv.Read()` loop. `TypeConverterException` is caught specifically and translated into clean one-line reasons like `Invalid value 'oops' for column 'Count'`, instead of CsvHelper's multi-line default that includes reader/parser state dumps.
- Post-load enrichment now collects warnings for set-code/set-name lookup misses.
- Blank rows and delimiter-only rows skipped silently (don't count toward errors).

### Console (`Program.cs`)
- Catches `HeaderValidationException` per file, logs a friendly error, continues.
- Skips writing the output CSV entirely when 0 cards were parsed across all files (no more empty `manabox-output-...csv` artifacts).

### Blazor (`MtgCsvProcessor.razor`)
- Red header-error alert when `HeaderValidationException` is caught (clear "Did you select the correct input format?" message).
- Severity-coloured Import Issues list (red errors, yellow warnings).
- **Download Error Report .csv** button gated on `errors > 0`.
- **Download Converted .csv** button gated on `cards > 0` — no empty downloads.
- State (summary, header error, issues, processed records, result stream) cleared at the top of `Convert()` so retries don't show stale results.

### Out of scope, filed separately
- #43 — Console UX improvements (cwd-relative `appsettings.json`, `-f` is pattern-only, misleading "Unsupported format" message).

## Invariant

The fault-tolerance contract is:

> `cards.Count + issues.Count(i => i.Severity == Error) == data_rows_in_csv`

Empty/blank lines are silently skipped. Warnings don't reduce the count (the card is still in the output).

## Test plan

- [x] `dotnet build`: 0 errors. (One pre-existing CA1506 coupling warning on `Program.Main`, unrelated.)
- [x] `dotnet test`: 69/69 passing.
- [x] New `FaultToleranceTests` covers the seven scenarios: happy path, invariant on mixed rows, all-invalid, warnings-only, mixed warnings+errors, header mismatch, blank/delimiter-only row skipping.
- [x] Console smoke-tested manually against the seven sample CSVs (`samples/fault-tolerance/`). All seven behaviors match expectations.
- [x] Blazor smoke-tested manually against cases 02 (mixed), 03 (all-invalid), 06 (wrong format). Layout, button visibility, and message wording match expectations.

## Sample CSVs

`samples/fault-tolerance/` includes seven hand-crafted Moxfield-format CSVs and a [README](https://github.com/StepKie/MtgCsvHelper/blob/feature/40-fault-tolerance/samples/fault-tolerance/README.md) mapping each file to expected behavior. Use them with `MOXFIELD` as the input format (file 6 deliberately mismatches to trigger the header error).