### PR TITLE
Enable show_full_output to debug silent claude-auto-review runs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,6 +54,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Enabled so we can debug why Claude posts nothing despite running successfully (issue: 2 consecutive PRs).
+          # Safe for our review prompts: no secrets in the input. Disable once auto-review is reliably commenting.
+          show_full_output: true
           prompt: |
             Please review this pull request for:
             - Code quality and .NET best practices

--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -177,7 +177,7 @@
 			var reader = new MtgCardCsvHandler(Api, Config, _selectedInputFormat);
 			var writer = new MtgCardCsvHandler(Api, Config, _selectedOutputFormat);
 
-			var result = reader.ParseCollectionCsv(csvStream);
+			var result = await reader.ParseCollectionCsvAsync(csvStream);
 			_summary = result.Collection.GenerateSummary();
 			_issues = result.Issues.ToList();
 

--- a/MtgCsvHelper.BlazorWebAssembly/wwwroot/appsettings.json
+++ b/MtgCsvHelper.BlazorWebAssembly/wwwroot/appsettings.json
@@ -318,6 +318,49 @@
                 "Foil": "TRUE",
                 "Etched": null
             }
+        },
+        {
+            "Name": "CARDMARKET",
+            "Delimiter": ";",
+            "Quantity": "groupCount",
+            "CardmarketId": "idProduct",
+            "Finish": {
+                "HeaderName": "isFoil",
+                "Foil": "1",
+                "Normal": "",
+                "Etched": null
+            },
+            "Condition": {
+                "HeaderName": "condition",
+                "Mint": "1",
+                "NearMint": "2",
+                "Excellent": "3",
+                "Good": "4",
+                "LightlyPlayed": "5",
+                "Played": "6",
+                "Poor": "7"
+            },
+            "Language": {
+                "HeaderName": "idLanguage",
+                "Mappings": {
+                    "en": "1",
+                    "fr": "2",
+                    "de": "3",
+                    "es": "4",
+                    "it": "5",
+                    "zhs": "6",
+                    "ja": "7",
+                    "pt": "8",
+                    "ru": "9",
+                    "ko": "10",
+                    "zht": "11"
+                }
+            },
+            "PriceBought": {
+                "HeaderName": "price",
+                "Currency": "EUR",
+                "CurrencySymbol": "Absent"
+            }
         }
     ]
 }

--- a/MtgCsvHelper.Tests/CardmarketTests.cs
+++ b/MtgCsvHelper.Tests/CardmarketTests.cs
@@ -1,0 +1,108 @@
+using System.Text;
+using CsvHelper;
+
+namespace MtgCsvHelper.Tests;
+
+[Collection(MtgApiCollection.Name)]
+public class CardmarketTests(MtgApiFixture fixture, ITestOutputHelper output) : ApiBaseTest(fixture, output)
+{
+	const string SamplePath = "Resources/SampleCsvs/Samples/cardmarket-sample.csv";
+
+	static MemoryStream CsvStream(string csv) => new(Encoding.UTF8.GetBytes(csv));
+
+	MtgCardCsvHandler Handler() => new(_api, _config, "CARDMARKET");
+
+	[Fact]
+	public async Task ParseSample_ResolvesAllFiveCardsViaScryfall()
+	{
+		var result = await Handler().ParseCollectionCsvAsync(SamplePath);
+
+		result.Collection.Cards.Should().HaveCount(5);
+		result.ErrorCount.Should().Be(0);
+		result.WarningCount.Should().Be(0);
+
+		var byName = result.Collection.Cards.ToDictionary(c => c.Printing.Name);
+
+		byName.Should().ContainKey("Pillory of the Sleepless");
+		byName.Should().ContainKey("Putrid Leech");
+		byName.Should().ContainKey("Master's Rebuke");
+		byName.Should().ContainKey("Cliffgate");
+		byName.Should().ContainKey("Serrated Arrows");
+
+		// Each card got a set populated from Scryfall (was empty in the source CSV).
+		result.Collection.Cards.Should().AllSatisfy(c => c.Printing.Set.Should().NotBeNullOrEmpty());
+		result.Collection.Cards.Should().AllSatisfy(c => c.Printing.SetName.Should().NotBeNullOrEmpty());
+	}
+
+	[Fact]
+	public async Task ParseSample_FoilFlagDecodedCorrectly()
+	{
+		var result = await Handler().ParseCollectionCsvAsync(SamplePath);
+		var byName = result.Collection.Cards.ToDictionary(c => c.Printing.Name);
+
+		byName["Master's Rebuke"].Foil.Should().Be(true);   // isFoil=1 in fixture
+		byName["Cliffgate"].Foil.Should().Be(true);         // isFoil=1 in fixture
+		byName["Putrid Leech"].Foil.Should().Be(false);     // isFoil empty in fixture
+	}
+
+	[Fact]
+	public async Task ParseSample_ConditionDecodedCorrectly()
+	{
+		var result = await Handler().ParseCollectionCsvAsync(SamplePath);
+		var byName = result.Collection.Cards.ToDictionary(c => c.Printing.Name);
+
+		byName["Pillory of the Sleepless"].Condition.Should().Be(CardCondition.EXCELLENT); // condition=3
+		byName["Putrid Leech"].Condition.Should().Be(CardCondition.NEAR_MINT);             // condition=2
+		byName["Serrated Arrows"].Condition.Should().Be(CardCondition.EXCELLENT);          // condition=3
+	}
+
+	[Fact]
+	public async Task ParseSample_LanguageDecodedCorrectly()
+	{
+		var result = await Handler().ParseCollectionCsvAsync(SamplePath);
+
+		// All rows in the fixture have idLanguage=1 → English ("en")
+		result.Collection.Cards.Should().AllSatisfy(c => c.Language.Should().Be("en"));
+	}
+
+	[Fact]
+	public async Task UnknownCardmarketId_RaisesWarning_KeepsOtherCards()
+	{
+		// 99999999 is far above any real cardmarket_id; Scryfall returns it as not_found.
+		var csv = "idProduct;groupCount;price;idLanguage;condition;isFoil;isSigned;isAltered;isPlayset;isReverseHolo;isFirstEd;isFullArt;isUberRare;isWithDie\n"
+			+ "266380;1;0.15;1;2;;;;;;;;;\n"     // valid: Putrid Leech
+			+ "99999999;1;0.10;1;2;;;;;;;;;\n";  // invalid: unknown ID
+
+		var result = await Handler().ParseCollectionCsvAsync(CsvStream(csv));
+
+		result.Collection.Cards.Should().HaveCount(2); // both rows parsed; one fails at the lookup step
+		result.ErrorCount.Should().Be(0);
+		result.WarningCount.Should().Be(1);
+		result.Issues[0].Reason.Should().Contain("99999999");
+		result.Issues[0].Severity.Should().Be(IssueSeverity.Warning);
+
+		// The valid card still resolved.
+		result.Collection.Cards.Should().Contain(c => c.Printing.Name == "Putrid Leech");
+	}
+
+	[Fact]
+	public void ParseWrongFormat_AsCardmarket_ThrowsHeaderValidationException()
+	{
+		// Moxfield-shaped CSV fed to the CARDMARKET handler — the required 'idProduct' / 'groupCount' headers are absent.
+		var csv = "Count,Name,Edition,Collector Number,Foil,Condition,Language,Purchase Price\n"
+			+ "1,Lightning Bolt,M11,149,,Near Mint,English,\n";
+
+		var act = async () => await Handler().ParseCollectionCsvAsync(CsvStream(csv));
+
+		act.Should().ThrowAsync<HeaderValidationException>();
+	}
+
+	[Fact]
+	public void GenerateWriteMap_ForCardmarket_Throws()
+	{
+		var factory = new CardMapFactory(_config, _api);
+		var act = () => factory.GenerateWriteMap("CARDMARKET");
+
+		act.Should().Throw<InvalidOperationException>().WithMessage("*read-only*");
+	}
+}

--- a/MtgCsvHelper.Tests/CardmarketTests.cs
+++ b/MtgCsvHelper.Tests/CardmarketTests.cs
@@ -66,7 +66,7 @@ public class CardmarketTests(MtgApiFixture fixture, ITestOutputHelper output) : 
 	}
 
 	[Fact]
-	public async Task UnknownCardmarketId_RaisesWarning_KeepsOtherCards()
+	public async Task UnknownCardmarketId_RaisesError_DropsCardKeepsOthers()
 	{
 		// 99999999 is far above any real cardmarket_id; Scryfall returns it as not_found.
 		var csv = "idProduct;groupCount;price;idLanguage;condition;isFoil;isSigned;isAltered;isPlayset;isReverseHolo;isFirstEd;isFullArt;isUberRare;isWithDie\n"
@@ -75,11 +75,12 @@ public class CardmarketTests(MtgApiFixture fixture, ITestOutputHelper output) : 
 
 		var result = await Handler().ParseCollectionCsvAsync(CsvStream(csv));
 
-		result.Collection.Cards.Should().HaveCount(2); // both rows parsed; one fails at the lookup step
-		result.ErrorCount.Should().Be(0);
-		result.WarningCount.Should().Be(1);
+		// The unresolved card is dropped (without name/set we can't write a meaningful row).
+		result.Collection.Cards.Should().HaveCount(1);
+		result.ErrorCount.Should().Be(1);
+		result.WarningCount.Should().Be(0);
 		result.Issues[0].Reason.Should().Contain("99999999");
-		result.Issues[0].Severity.Should().Be(IssueSeverity.Warning);
+		result.Issues[0].Severity.Should().Be(IssueSeverity.Error);
 
 		// The valid card still resolved.
 		result.Collection.Cards.Should().Contain(c => c.Printing.Name == "Putrid Leech");

--- a/MtgCsvHelper/CardMapFactory.cs
+++ b/MtgCsvHelper/CardMapFactory.cs
@@ -9,11 +9,13 @@ public class CardMapFactory(IConfiguration config, IMtgApi api)
 {
 	readonly List<FormatConfig> _formatConfigs = From(config).ToList();
 
-	public static List<string> Supported { get; } = ["MOXFIELD", "DRAGONSHIELD", "MANABOX", "TOPDECKED", "DECKBOX", "CARDKINGDOM", "MTGGOLDFISH", "TCGPLAYER"];
+	public static List<string> Supported { get; } = ["MOXFIELD", "DRAGONSHIELD", "MANABOX", "TOPDECKED", "DECKBOX", "CARDKINGDOM", "MTGGOLDFISH", "TCGPLAYER", "CARDMARKET"];
 	public static List<string> NotYetFullySupported { get; } = ["URZAGATHERER"];
 
-	// Formats that cannot be parsed (their CSV does not carry enough information to recover a canonical card).
+	// Formats whose CSV doesn't carry enough info to populate a complete card without external lookups,
+	// or that don't make sense as targets for our writers.
 	static readonly HashSet<string> WriteOnlyFormats = new(StringComparer.OrdinalIgnoreCase) { "CARDKINGDOM" };
+	static readonly HashSet<string> ReadOnlyFormats = new(StringComparer.OrdinalIgnoreCase) { "CARDMARKET" };
 
 	public static IEnumerable<FormatConfig> From(IConfiguration config) =>
 		config.GetSection("CsvConfigurations")
@@ -29,12 +31,18 @@ public class CardMapFactory(IConfiguration config, IMtgApi api)
 		{
 			throw new InvalidOperationException($"Format '{format}' is write-only and cannot be parsed.");
 		}
+		ValidateCardIdentifier(cfg);
 		return new PhysicalCardMap(cfg, api);
 	}
 
 	public ClassMap<PhysicalMtgCard> GenerateWriteMap(string format)
 	{
 		var cfg = RequireFormat(format);
+		if (ReadOnlyFormats.Contains(format))
+		{
+			throw new InvalidOperationException($"Format '{format}' is read-only and cannot be written.");
+		}
+		ValidateCardIdentifier(cfg);
 		return format.Equals("CARDKINGDOM", StringComparison.OrdinalIgnoreCase)
 			? new CardKingdomWriteMap(cfg, api)
 			: new PhysicalCardMap(cfg, api);
@@ -42,4 +50,12 @@ public class CardMapFactory(IConfiguration config, IMtgApi api)
 
 	FormatConfig RequireFormat(string format) => GetFormatConfig(format)
 		?? throw new ArgumentException($"Unsupported format '{format}'. Supported: {string.Join(", ", Supported)}.", nameof(format));
+
+	static void ValidateCardIdentifier(FormatConfig cfg)
+	{
+		if (cfg.CardName is null && cfg.CardmarketId is null)
+		{
+			throw new InvalidOperationException($"Format '{cfg.Name}' must specify either a CardName or a CardmarketId column.");
+		}
+	}
 }

--- a/MtgCsvHelper/FormatConfig.cs
+++ b/MtgCsvHelper/FormatConfig.cs
@@ -3,14 +3,20 @@ namespace MtgCsvHelper;
 public record FormatConfig(
 	string Name,
 	string Quantity,
-	CardNameConfiguration CardName,
+	// Either CardName or CardmarketId (or in the future another card-identifier kind) must be set.
+	// Most formats identify cards by name + set; Cardmarket identifies by its internal product ID and
+	// requires Scryfall reverse-lookup to fill in name/set/etc. during enrichment.
+	CardNameConfiguration? CardName = null,
+	string? CardmarketId = null,
 	string? SetNumber = null,
 	string? SetCode = null,
 	string? SetName = null,
 	FinishConfiguration? Finish = null,
 	ConditionConfiguration? Condition = null,
 	LanguageConfiguration? Language = null,
-	PriceConfiguration? PriceBought = null
+	PriceConfiguration? PriceBought = null,
+	// CSV delimiter. Most sites use comma; Cardmarket exports use semicolon.
+	string Delimiter = ","
 	)
 {
 	public Currency Currency => Currency.FromString(PriceBought?.Currency);

--- a/MtgCsvHelper/Maps/CardKingdomWriteMap.cs
+++ b/MtgCsvHelper/Maps/CardKingdomWriteMap.cs
@@ -10,6 +10,7 @@ public class CardKingdomWriteMap : ClassMap<PhysicalMtgCard>
 {
 	public CardKingdomWriteMap(FormatConfig columnConfig, IMtgApi api)
 	{
+		_ = columnConfig.CardName ?? throw new InvalidOperationException($"Format '{columnConfig.Name}' is missing the required 'CardName' configuration section.");
 		_ = columnConfig.Finish ?? throw new InvalidOperationException($"Format '{columnConfig.Name}' is missing the required 'Finish' configuration section.");
 
 		Map(card => card.Printing.Name).TypeConverter(new CardNameConverter(columnConfig.CardName, api)).Name(columnConfig.CardName.HeaderName).Index(0);

--- a/MtgCsvHelper/Maps/PhysicalCardMap.cs
+++ b/MtgCsvHelper/Maps/PhysicalCardMap.cs
@@ -14,9 +14,21 @@ public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 	public PhysicalCardMap(FormatConfig cfg, IMtgApi api)
 	{
 		Map(c => c.Count).Name(cfg.Quantity).Index(1);
-		Map(c => c.Printing.Name)
-			.TypeConverter(new CardNameConverter(cfg.CardName, api))
-			.Name(cfg.CardName.HeaderName).Index(0);
+
+		// Card identification: most formats use a card-name column; Cardmarket uses an external ID.
+		// At least one must be set (validated in CardMapFactory).
+		if (cfg.CardName is not null)
+		{
+			Map(c => c.Printing.Name)
+				.TypeConverter(new CardNameConverter(cfg.CardName, api))
+				.Name(cfg.CardName.HeaderName).Index(0);
+		}
+		if (cfg.CardmarketId is not null)
+		{
+			// Stub Card object: only CardMarketId is filled here; name/set/etc. get resolved
+			// later in MtgCardCsvHandler.EnrichByCardmarketIdAsync via batched Scryfall lookup.
+			Map(c => c.Printing.CardMarketId).Name(cfg.CardmarketId);
+		}
 
 		// At least one of SetCode / SetName is expected per format (sites differ on which they include).
 		MapOptional(c => c.Printing.CollectorNumber, cfg.SetNumber);

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -18,30 +18,46 @@ public class MtgCardCsvHandler
 		_api = api;
 	}
 
-	public ParseResult ParseCollectionCsv(string csvFilePath) => ParseCollectionCsv(File.OpenRead(csvFilePath));
+	// Sync wrappers — fine for non-Blazor callers and for formats that don't need network I/O.
+	// Cardmarket forces async (Scryfall lookups), so the sync path blocks on the async path.
+	public ParseResult ParseCollectionCsv(string csvFilePath) => ParseCollectionCsvAsync(csvFilePath).GetAwaiter().GetResult();
+	public ParseResult ParseCollectionCsv(Stream csvStream) => ParseCollectionCsvAsync(csvStream).GetAwaiter().GetResult();
 
-	public ParseResult ParseCollectionCsv(Stream csvStream)
+	public Task<ParseResult> ParseCollectionCsvAsync(string csvFilePath) => ParseCollectionCsvAsync(File.OpenRead(csvFilePath));
+
+	public async Task<ParseResult> ParseCollectionCsvAsync(Stream csvStream)
 	{
 		Log.Information($"Parsing input format {_format} ...");
 		using var reader = new StreamReader(csvStream);
 		CheckIfFirstLineCanBeIgnored(reader);
 
-		using var csv = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture) { MissingFieldFound = null });
+		var formatConfig = _factory.GetFormatConfig(_format)
+			?? throw new InvalidOperationException($"Format '{_format}' configuration not found.");
+
+		using var csv = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture)
+		{
+			MissingFieldFound = null,
+			Delimiter = formatConfig.Delimiter,
+		});
 		csv.Context.RegisterClassMap(_factory.GenerateReadMap(_format));
 
-		if (!csv.Read())
+		if (!await csv.ReadAsync())
 		{
-			// Empty file — no header, no rows. Return empty result rather than treating as an error.
+			// Empty file — no header, no rows.
 			return new ParseResult(new Collection { Name = $"Import {_format}, Date: {DateTime.Now}", Cards = [] }, []);
 		}
 		csv.ReadHeader();
 		csv.ValidateHeader<PhysicalMtgCard>(); // throws HeaderValidationException if non-Optional fields are missing
 
 		var cards = new List<PhysicalMtgCard>();
+		var rowNumbers = new List<int>(); // parallel to cards; needed for issue reporting in the post-parse enrichment step
 		var issues = new List<ImportIssue>();
+		// Sets are pre-loaded into the cached IMtgApi during startup; the sync accessor is a property read, not network I/O.
+#pragma warning disable CA1849
 		var sets = _api.GetSets();
+#pragma warning restore CA1849
 
-		while (csv.Read())
+		while (await csv.ReadAsync())
 		{
 			// Skip rows that are blank or contain only delimiters/whitespace.
 			if (csv.Parser.Record is null || csv.Parser.Record.All(string.IsNullOrWhiteSpace))
@@ -53,8 +69,14 @@ public class MtgCardCsvHandler
 			try
 			{
 				var card = csv.GetRecord<PhysicalMtgCard>();
-				EnrichSetInfo(card, sets, issues, rowNum);
+				// For non-cardmarket formats, the printing's Name is set during parse; backfill set info now.
+				// For cardmarket-style stubs (Name empty, CardMarketId set), defer to the cardmarket enricher.
+				if (!string.IsNullOrEmpty(card.Printing.Name))
+				{
+					EnrichSetInfo(card, sets, issues, rowNum);
+				}
 				cards.Add(card);
+				rowNumbers.Add(rowNum);
 			}
 			catch (TypeConverterException tcex)
 			{
@@ -75,6 +97,9 @@ public class MtgCardCsvHandler
 					RawContent: csv.Parser.RawRecord?.TrimEnd()));
 			}
 		}
+
+		// Post-parse enrichment: fill in stubbed cards (Cardmarket) by batched Scryfall lookup.
+		await EnrichByCardmarketIdAsync(cards, rowNumbers, issues);
 
 		var collection = new Collection { Name = $"Import {_format}, Date: {DateTime.Now}", Cards = cards };
 		Log.Debug(collection.GenerateSummary());
@@ -113,6 +138,45 @@ public class MtgCardCsvHandler
 		else if (hadSetName && p.Set is null)
 		{
 			issues.Add(new ImportIssue(IssueSeverity.Warning, rowNum, $"Set name '{p.SetName}' not found in Scryfall data", CardName: p.Name));
+		}
+	}
+
+	// For cards whose Printing was parsed as a stub (only CardMarketId set), batch-resolve the
+	// full Scryfall card by cardmarket_id and fill in name/set/setName/collectorNumber.
+	// IDs not found in Scryfall produce an ImportIssue.Warning per affected card.
+	async Task EnrichByCardmarketIdAsync(IList<PhysicalMtgCard> cards, IList<int> rowNumbers, List<ImportIssue> issues)
+	{
+		// CardMarketId is `int` (not `int?`) in the Scryfall library, so 0 acts as the "unset" sentinel —
+		// real cardmarket_ids are always positive in Scryfall data.
+		var pending = new List<(PhysicalMtgCard Card, int RowNum)>();
+		for (int i = 0; i < cards.Count; i++)
+		{
+			var c = cards[i];
+			if (c.Printing.CardMarketId > 0 && string.IsNullOrEmpty(c.Printing.Name))
+			{
+				pending.Add((c, rowNumbers[i]));
+			}
+		}
+
+		if (pending.Count == 0) return;
+
+		var ids = pending.Select(x => x.Card.Printing.CardMarketId).Distinct().ToList();
+		var resolved = await _api.GetCardsByCardmarketIdsAsync(ids);
+
+		foreach (var entry in pending)
+		{
+			var id = entry.Card.Printing.CardMarketId;
+			if (resolved.TryGetValue(id, out var full))
+			{
+				entry.Card.Printing.Name = full.Name;
+				entry.Card.Printing.Set = full.Set;
+				entry.Card.Printing.SetName = full.SetName;
+				entry.Card.Printing.CollectorNumber = full.CollectorNumber;
+			}
+			else
+			{
+				issues.Add(new ImportIssue(IssueSeverity.Warning, entry.RowNum, $"Cardmarket ID {id} not found in Scryfall data"));
+			}
 		}
 	}
 

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -163,6 +163,7 @@ public class MtgCardCsvHandler
 		var ids = pending.Select(x => x.Card.Printing.CardMarketId).Distinct().ToList();
 		var resolved = await _api.GetCardsByCardmarketIdsAsync(ids);
 
+		var unresolved = new List<PhysicalMtgCard>();
 		foreach (var entry in pending)
 		{
 			var id = entry.Card.Printing.CardMarketId;
@@ -175,8 +176,15 @@ public class MtgCardCsvHandler
 			}
 			else
 			{
-				issues.Add(new ImportIssue(IssueSeverity.Warning, entry.RowNum, $"Cardmarket ID {id} not found in Scryfall data"));
+				// Without a name/set, we can't write a meaningful row — drop the card.
+				// This is data loss (Error), not just degraded fidelity (Warning).
+				issues.Add(new ImportIssue(IssueSeverity.Error, entry.RowNum, $"Cardmarket ID {id} not found in Scryfall data — card skipped"));
+				unresolved.Add(entry.Card);
 			}
+		}
+		foreach (var dropped in unresolved)
+		{
+			cards.Remove(dropped);
 		}
 	}
 

--- a/MtgCsvHelper/Resources/SampleCsvs/Samples/cardmarket-sample.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Samples/cardmarket-sample.csv
@@ -1,0 +1,6 @@
+idProduct;groupCount;price;idLanguage;condition;isFoil;isSigned;isAltered;isPlayset;isReverseHolo;isFirstEd;isFullArt;isUberRare;isWithDie
+13232;1;0.10;1;3;;;;;;;;;
+266380;1;0.15;1;2;;;;;;;;;
+608268;1;0.14;1;2;1;;;;;;;;
+660938;1;0.95;1;2;1;;;;;;;;
+16618;1;0.83;1;3;;;;;;;;;

--- a/MtgCsvHelper/Services/CachedMtgApi.cs
+++ b/MtgCsvHelper/Services/CachedMtgApi.cs
@@ -14,6 +14,7 @@ public class CachedMtgApi : IMtgApi
 	List<string> _doubleFacedCardNames;
 	List<string> _tokenCardNames;
 	List<Set> _sets;
+	readonly Dictionary<int, Card> _cardsByCardmarketId = [];
 
 	public CachedMtgApi(ScryfallApiClient api)
 	{
@@ -93,4 +94,53 @@ public class CachedMtgApi : IMtgApi
 	public List<string> GetDoubleFacedCardNames() => _doubleFacedCardNames;
 
 	public List<string> GetTokenCardNames() => _tokenCardNames;
+
+	// Scryfall's batch /cards/collection endpoint does NOT accept cardmarket_id as an identifier (only id,
+	// mtgo_id, multiverse_id, oracle_id, illustration_id, name, name+set, set+collector_number). So we use
+	// the per-card /cards/cardmarket/{id} endpoint sequentially, with the 50ms inter-request delay Scryfall asks for.
+	const int InterRequestDelayMs = 50;
+	static readonly JsonSerializerOptions ScryfallJsonOptions = new()
+	{
+		PropertyNameCaseInsensitive = true,
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+	};
+
+	public async Task<IReadOnlyDictionary<int, Card>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds)
+	{
+		var requested = cardmarketIds.Distinct().ToList();
+		var notYetFetched = requested.Where(id => !_cardsByCardmarketId.ContainsKey(id)).ToList();
+
+		for (int i = 0; i < notYetFetched.Count; i++)
+		{
+			var id = notYetFetched[i];
+			try
+			{
+				var response = await DEFAULT_CLIENT.GetAsync(new Uri($"https://api.scryfall.com/cards/cardmarket/{id}"));
+				if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+				{
+					continue; // not found — caller will see this id absent from the returned dictionary
+				}
+				response.EnsureSuccessStatusCode();
+				var body = await response.Content.ReadAsStringAsync();
+				var card = JsonSerializer.Deserialize<Card>(body, ScryfallJsonOptions);
+				if (card is not null)
+				{
+					_cardsByCardmarketId[id] = card;
+				}
+			}
+			catch (HttpRequestException ex)
+			{
+				Log.Warning(ex, $"Failed to resolve cardmarket_id {id}");
+			}
+
+			if (i + 1 < notYetFetched.Count)
+			{
+				await Task.Delay(InterRequestDelayMs);
+			}
+		}
+
+		return requested
+			.Where(_cardsByCardmarketId.ContainsKey)
+			.ToDictionary(id => id, id => _cardsByCardmarketId[id]);
+	}
 }

--- a/MtgCsvHelper/Services/IMtgApi.cs
+++ b/MtgCsvHelper/Services/IMtgApi.cs
@@ -13,5 +13,9 @@ public interface IMtgApi
 	Task<IEnumerable<Card>> GetTokenCardNamesAsync();
 	List<string> GetTokenCardNames();
 
+	// Batched lookup of Scryfall cards by their cardmarket_id. Missing IDs are absent from the returned dictionary.
+	// Cached: subsequent calls for already-resolved IDs return instantly without hitting the network.
+	Task<IReadOnlyDictionary<int, Card>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds);
+
 	Task LoadData();
 }

--- a/MtgCsvHelper/appsettings.json
+++ b/MtgCsvHelper/appsettings.json
@@ -318,6 +318,49 @@
         "Foil": "TRUE",
         "Etched": null
       }
+    },
+    {
+      "Name": "CARDMARKET",
+      "Delimiter": ";",
+      "Quantity": "groupCount",
+      "CardmarketId": "idProduct",
+      "Finish": {
+        "HeaderName": "isFoil",
+        "Foil": "1",
+        "Normal": "",
+        "Etched": null
+      },
+      "Condition": {
+        "HeaderName": "condition",
+        "Mint": "1",
+        "NearMint": "2",
+        "Excellent": "3",
+        "Good": "4",
+        "LightlyPlayed": "5",
+        "Played": "6",
+        "Poor": "7"
+      },
+      "Language": {
+        "HeaderName": "idLanguage",
+        "Mappings": {
+          "en": "1",
+          "fr": "2",
+          "de": "3",
+          "es": "4",
+          "it": "5",
+          "zhs": "6",
+          "ja": "7",
+          "pt": "8",
+          "ru": "9",
+          "ko": "10",
+          "zht": "11"
+        }
+      },
+      "PriceBought": {
+        "HeaderName": "price",
+        "Currency": "EUR",
+        "CurrencySymbol": "Absent"
+      }
     }
   ],
   "Serilog": {


### PR DESCRIPTION
The auto-review action has been running successfully for two consecutive PRs (#44 and #47) but posting nothing — neither inline nor summary. Each run logs:

\`\`\`
is_error: false
num_turns: 4-6
permission_denials_count: 1-3
No buffered inline comments
\`\`\`

So Claude is doing 4-6 turns of work, hitting at least one tool denial, and silently giving up. Without `show_full_output: true` the action hides Claude's reasoning — we can't see which tool is getting denied.

This PR enables the flag for the auto-review job. The first run that exercises it will be **this very PR's auto-review run**, which we can read for diagnosis.

Once we know what's wrong and it's fixed, this flag should be turned back off (it does increase log noise).

## Test plan

- [ ] PR auto-review run completes (`success` regardless)
- [ ] Logs now include Claude's reasoning + which tool got denied
- [ ] Fix follow-up PR addresses whatever the denial was