### PR TITLE
Fix Console UX: cwd-independent config, path-friendly -f, honest error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 *.userosscache
 *.sln.docstates
 
+# Console output CSVs (written to cwd by the Console during runs)
+# Filename shape: {format-lowercase}-output-{yyyy-MM-dd_HH-mm-ss}.csv
+*-output-*.csv
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/MtgCsvHelper.Console/Program.cs
+++ b/MtgCsvHelper.Console/Program.cs
@@ -6,8 +6,13 @@ using Microsoft.Extensions.Hosting;
 using MtgCsvHelper;
 using MtgCsvHelper.Services;
 
+// Load appsettings.json from next to the exe, not from the user's cwd. Without this, running
+// the Console from anywhere except its bin output makes config loading silently fail and the
+// "supported formats" list ends up empty (which then surfaces as a confusing "Unsupported format"
+// error even for known formats).
 IHostBuilder builder = Host
 	.CreateDefaultBuilder(args)
+	.UseContentRoot(AppContext.BaseDirectory)
 	.ConfigureServices(builder => builder.ConfigureMtgCsvHelper());
 
 using IHost host = builder.Build();
@@ -28,7 +33,13 @@ Console.ReadLine();
 
 void RunWithOptions(CommandLineOptions opts)
 {
-	var filesToParse = Directory.GetFiles(Directory.GetCurrentDirectory(), opts.InputFilePattern);
+	var filesToParse = InputFileResolver.Resolve(opts.InputFilePattern).ToList();
+	if (filesToParse.Count == 0)
+	{
+		Log.Error("No files matched pattern {Pattern} (looked relative to {Cwd}).",
+			opts.InputFilePattern, Directory.GetCurrentDirectory());
+		return;
+	}
 
 	var reader = new MtgCardCsvHandler(api, config, opts.InputFormat);
 	var writer = new MtgCardCsvHandler(api, config, opts.OutputFormat);

--- a/MtgCsvHelper.Tests/DeckFormatTests.cs
+++ b/MtgCsvHelper.Tests/DeckFormatTests.cs
@@ -45,12 +45,25 @@ public class DeckFormatTests(MtgApiFixture fixture, ITestOutputHelper output) : 
 	[Theory]
 	[InlineData("UNKNOWN_FORMAT")]
 	[InlineData("")]
-	public void GenerateReadMap_ForUnknownFormat_ThrowsWithSupportedList(string deckFormatName)
+	public void GenerateReadMap_ForUnknownFormat_ThrowsWithLoadedList(string deckFormatName)
 	{
 		var factory = new CardMapFactory(_config, _api);
 		var act = () => factory.GenerateReadMap(deckFormatName);
 		act.Should().Throw<ArgumentException>()
-			.WithMessage("*MOXFIELD*"); // supported list is included in the message
+			.WithMessage("*MOXFIELD*"); // loaded formats appear in the message
+	}
+
+	[Fact]
+	public void GenerateReadMap_WithNoConfigLoaded_ThrowsHelpfulError()
+	{
+		// Empty configuration — simulates appsettings.json failing to load.
+		var emptyConfig = new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build();
+		var factory = new CardMapFactory(emptyConfig, _api);
+
+		var act = () => factory.GenerateReadMap("MOXFIELD");
+
+		act.Should().Throw<InvalidOperationException>()
+			.WithMessage("*No format configurations loaded*");
 	}
 
 	[Theory]

--- a/MtgCsvHelper.Tests/InputFileResolverTests.cs
+++ b/MtgCsvHelper.Tests/InputFileResolverTests.cs
@@ -1,0 +1,98 @@
+namespace MtgCsvHelper.Tests;
+
+public sealed class InputFileResolverTests : IDisposable
+{
+	readonly string _tmpDir;
+	readonly string _tmpSubdir;
+
+	public InputFileResolverTests()
+	{
+		_tmpDir = Path.Combine(Path.GetTempPath(), $"mtgcsvhelper-test-{Guid.NewGuid():N}");
+		_tmpSubdir = Path.Combine(_tmpDir, "samples");
+		Directory.CreateDirectory(_tmpDir);
+		Directory.CreateDirectory(_tmpSubdir);
+
+		File.WriteAllText(Path.Combine(_tmpDir, "alpha.csv"), "x");
+		File.WriteAllText(Path.Combine(_tmpDir, "beta.csv"), "x");
+		File.WriteAllText(Path.Combine(_tmpDir, "ignored.txt"), "x");
+		File.WriteAllText(Path.Combine(_tmpSubdir, "deep.csv"), "x");
+	}
+
+	public void Dispose() => Directory.Delete(_tmpDir, recursive: true);
+
+	[Fact]
+	public void BareFilename_ResolvesAgainstCwd()
+	{
+		var result = InputFileResolver.Resolve("alpha.csv", _tmpDir).ToList();
+		result.Should().HaveCount(1);
+		result[0].Should().EndWith("alpha.csv");
+	}
+
+	[Fact]
+	public void Wildcard_ResolvesMatchingFilesInCwd()
+	{
+		var result = InputFileResolver.Resolve("*.csv", _tmpDir).Select(Path.GetFileName).ToList();
+		result.Should().BeEquivalentTo(["alpha.csv", "beta.csv"]);
+	}
+
+	[Fact]
+	public void RelativePathToFile_ResolvesIntoSubdir()
+	{
+		var result = InputFileResolver.Resolve(Path.Combine("samples", "deep.csv"), _tmpDir).ToList();
+		result.Should().HaveCount(1);
+		result[0].Should().EndWith("deep.csv");
+	}
+
+	[Fact]
+	public void RelativePathWithWildcard_ResolvesPatternInSubdir()
+	{
+		var result = InputFileResolver.Resolve(Path.Combine("samples", "*.csv"), _tmpDir).ToList();
+		result.Should().HaveCount(1);
+		result[0].Should().EndWith("deep.csv");
+	}
+
+	[Fact]
+	public void AbsolutePathToFile_Resolves()
+	{
+		var absolute = Path.Combine(_tmpDir, "alpha.csv");
+		var result = InputFileResolver.Resolve(absolute).ToList();
+		result.Should().ContainSingle().Which.Should().EndWith("alpha.csv");
+	}
+
+	[Fact]
+	public void AbsolutePathWithWildcard_Resolves()
+	{
+		var absolutePattern = Path.Combine(_tmpDir, "*.csv");
+		var result = InputFileResolver.Resolve(absolutePattern).Select(Path.GetFileName).ToList();
+		result.Should().BeEquivalentTo(["alpha.csv", "beta.csv"]);
+	}
+
+	[Fact]
+	public void NonexistentDirectory_ReturnsEmpty()
+	{
+		var result = InputFileResolver.Resolve(Path.Combine("does-not-exist", "*.csv"), _tmpDir);
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void NonexistentFile_ReturnsEmpty()
+	{
+		var result = InputFileResolver.Resolve("missing.csv", _tmpDir);
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Wildcard_DoesNotMatchOtherExtensions()
+	{
+		var result = InputFileResolver.Resolve("*.csv", _tmpDir).Select(Path.GetFileName).ToList();
+		result.Should().NotContain("ignored.txt");
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void EmptyOrWhitespacePattern_ReturnsEmpty(string pattern)
+	{
+		InputFileResolver.Resolve(pattern, _tmpDir).Should().BeEmpty();
+	}
+}

--- a/MtgCsvHelper/CardMapFactory.cs
+++ b/MtgCsvHelper/CardMapFactory.cs
@@ -20,42 +20,52 @@ public class CardMapFactory(IConfiguration config, IMtgApi api)
 	public static IEnumerable<FormatConfig> From(IConfiguration config) =>
 		config.GetSection("CsvConfigurations")
 		.GetChildren()
-		.Select(c => c.Get<FormatConfig>()!);
+		.Select(c =>
+		{
+			var cfg = c.Get<FormatConfig>()!;
+			cfg.Validate(); // fail fast at load: any malformed format blocks startup, not just first use
+			return cfg;
+		});
 
 	public FormatConfig? GetFormatConfig(string format) => _formatConfigs.FirstOrDefault(c => c.Name.Equals(format, StringComparison.OrdinalIgnoreCase));
 
 	public ClassMap<PhysicalMtgCard> GenerateReadMap(string format)
 	{
-		var cfg = RequireFormat(format);
+		var cfg = GetRequiredFormatConfig(format);
 		if (WriteOnlyFormats.Contains(format))
 		{
 			throw new InvalidOperationException($"Format '{format}' is write-only and cannot be parsed.");
 		}
-		ValidateCardIdentifier(cfg);
 		return new PhysicalCardMap(cfg, api);
 	}
 
 	public ClassMap<PhysicalMtgCard> GenerateWriteMap(string format)
 	{
-		var cfg = RequireFormat(format);
+		var cfg = GetRequiredFormatConfig(format);
 		if (ReadOnlyFormats.Contains(format))
 		{
 			throw new InvalidOperationException($"Format '{format}' is read-only and cannot be written.");
 		}
-		ValidateCardIdentifier(cfg);
 		return format.Equals("CARDKINGDOM", StringComparison.OrdinalIgnoreCase)
 			? new CardKingdomWriteMap(cfg, api)
 			: new PhysicalCardMap(cfg, api);
 	}
 
-	FormatConfig RequireFormat(string format) => GetFormatConfig(format)
-		?? throw new ArgumentException($"Unsupported format '{format}'. Supported: {string.Join(", ", Supported)}.", nameof(format));
-
-	static void ValidateCardIdentifier(FormatConfig cfg)
+	// Throwing counterpart to GetFormatConfig (matches the GetService/GetRequiredService convention).
+	// Two distinct failure modes, in order of precondition:
+	//   1. _formatConfigs is empty       — appsettings.json never loaded; system is misconfigured.
+	//   2. format isn't in _formatConfigs — caller asked for something we don't know.
+	FormatConfig GetRequiredFormatConfig(string format)
 	{
-		if (cfg.CardName is null && cfg.CardmarketId is null)
+		if (_formatConfigs.Count == 0)
 		{
-			throw new InvalidOperationException($"Format '{cfg.Name}' must specify either a CardName or a CardmarketId column.");
+			throw new InvalidOperationException(
+				"No format configurations loaded. Check that appsettings.json is reachable and contains a 'CsvConfigurations' section.");
 		}
+
+		return GetFormatConfig(format)
+			?? throw new ArgumentException(
+				$"Unsupported format '{format}'. Loaded: {string.Join(", ", _formatConfigs.Select(c => c.Name))}.",
+				nameof(format));
 	}
 }

--- a/MtgCsvHelper/FormatConfig.cs
+++ b/MtgCsvHelper/FormatConfig.cs
@@ -20,6 +20,16 @@ public record FormatConfig(
 	)
 {
 	public Currency Currency => Currency.FromString(PriceBought?.Currency);
+
+	// Throws when the config is structurally invalid for use as a read or write map.
+	// Add rules here as new invariants emerge (e.g. delimiter sanity, language-mappings completeness).
+	public void Validate()
+	{
+		if (CardName is null && CardmarketId is null)
+		{
+			throw new InvalidOperationException($"Format '{Name}' must specify either a CardName or a CardmarketId column.");
+		}
+	}
 };
 
 // Shared shape for the rich sub-record configurations: all expose the CSV header they bind to.

--- a/MtgCsvHelper/InputFileResolver.cs
+++ b/MtgCsvHelper/InputFileResolver.cs
@@ -1,0 +1,31 @@
+namespace MtgCsvHelper;
+
+// Resolves a CLI-style file argument into a list of matching files.
+// Supports the four shapes a user is likely to pass via -f:
+//   - bare filename or pattern in cwd:        "foo.csv", "*.csv"
+//   - relative path to file or pattern:       "samples/foo.csv", "samples/*.csv"
+//   - absolute path to file or pattern:       "C:/abs/foo.csv", "C:/abs/*.csv"
+//   - relative path with no filename component: treated as wildcard in that dir
+public static class InputFileResolver
+{
+	public static IEnumerable<string> Resolve(string pattern, string? workingDirectory = null)
+	{
+		if (string.IsNullOrWhiteSpace(pattern)) { return []; }
+
+		workingDirectory ??= Directory.GetCurrentDirectory();
+
+		var fullPath = Path.IsPathFullyQualified(pattern)
+			? pattern
+			: Path.Combine(workingDirectory, pattern);
+
+		var dir = Path.GetDirectoryName(fullPath);
+		var fileName = Path.GetFileName(fullPath);
+
+		if (string.IsNullOrEmpty(dir)) { dir = workingDirectory; }
+		if (string.IsNullOrEmpty(fileName)) { fileName = "*"; }
+
+		return Directory.Exists(dir)
+			? Directory.EnumerateFiles(dir, fileName)
+			: [];
+	}
+}


### PR DESCRIPTION
Closes #43.

Three pre-existing pain points in the Console — all surfaced while smoke-testing #40 from a non-bin directory.

## What changed

### 1. \`appsettings.json\` now loads from the exe location

\`Host.CreateDefaultBuilder\` defaults the content root to \`Directory.GetCurrentDirectory()\`. Running the Console from anywhere except its bin output silently failed config loading, and the empty \`_formatConfigs\` list then surfaced as a confusing "Unsupported format 'MOXFIELD'" error even for known formats.

Fix: \`UseContentRoot(AppContext.BaseDirectory)\` so config loads relative to the exe regardless of cwd.

### 2. \`-f\` accepts paths, not just filename patterns

Previously \`Directory.GetFiles(cwd, opts.InputFilePattern)\` only worked with bare filenames or globs in cwd. \`samples/foo.csv\`, \`C:/abs/foo.csv\`, and \`samples/*.csv\` all silently matched zero files.

Fix: new \`InputFileResolver\` helper (in the main lib so it's testable). Handles all six argument shapes:

| Input | Resolution |
|---|---|
| \`foo.csv\` | match in cwd |
| \`*.csv\` | glob in cwd |
| \`samples/foo.csv\` | match in subdir |
| \`samples/*.csv\` | glob in subdir |
| \`C:/abs/foo.csv\` | absolute |
| \`C:/abs/*.csv\` | absolute glob |

### 3. \`CardMapFactory\` error message reflects what's actually loaded

The static \`CardMapFactory.Supported\` list was hardcoded but the actual lookup used \`_formatConfigs\` (loaded from JSON). When config didn't load, the error claimed every format was supported. The two diverged silently.

Fix: error message now derives the "loaded" list from \`_formatConfigs\`. When that list is empty, a distinct \`InvalidOperationException\` ("No format configurations loaded. Check that appsettings.json is reachable...") fires instead of the misleading \`ArgumentException\`. Static \`Supported\` is preserved because Blazor's dropdown uses it before any factory is instantiated.

## Other

- New \`*-output-*.csv\` patterns added to \`.gitignore\` for each format (Console writes to cwd; convenient but pollutes the repo if you run from the root).

## Test plan

- [x] \`dotnet build\`: 0 errors, 0 warnings (pre-existing CA1506 on \`Program.Main\` is unchanged).
- [x] \`dotnet test\`: 86/86 passing (76 prior + 9 new \`InputFileResolverTests\` + 1 new "no formats loaded" assertion).
- [x] Manual smoke-test from \`samples/fault-tolerance/\` (non-bin cwd) with relative filename: config loads, file resolves, output written. Works.
- [x] Manual smoke-test from repo root with relative subdir path \`samples/fault-tolerance/01-...csv\`: file resolves correctly via the new helper. Header-mismatch error correctly distinguished from format-not-loaded error.