### PR TITLE
Centralize version, derive User-Agent from assembly

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+
+	<PropertyGroup>
+		<!--
+			Single source of truth for the project version. All .csproj files in the solution
+			inherit this. MSBuild auto-derives AssemblyVersion / FileVersion / InformationalVersion
+			from <Version>, so reading via Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+			gives the same string back.
+
+			Bump this on each release; do not put <Version> in individual .csproj files.
+		-->
+		<Version>1.1.0</Version>
+	</PropertyGroup>
+
+</Project>

--- a/MtgCsvHelper.BlazorWebAssembly/MtgCsvHelper.BlazorWebAssembly.csproj
+++ b/MtgCsvHelper.BlazorWebAssembly/MtgCsvHelper.BlazorWebAssembly.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <NullabilityInfoContextSupport>true</NullabilityInfoContextSupport>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>1.1.0</Version>
+    <!-- Version is set in Directory.Build.props at the repo root. -->
   </PropertyGroup>
   <PropertyGroup>
     <BlazorWebAssemblyEnableAOT>false</BlazorWebAssemblyEnableAOT>

--- a/MtgCsvHelper.Tests/AppInfoTests.cs
+++ b/MtgCsvHelper.Tests/AppInfoTests.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+
+namespace MtgCsvHelper.Tests;
+
+public class AppInfoTests
+{
+	[Fact]
+	public void Version_MatchesAssemblyInformationalVersion()
+	{
+		var expected = typeof(AppInfo).Assembly
+			.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+		expected.Should().NotBeNullOrEmpty(because: "the assembly must carry InformationalVersion (set via Directory.Build.props)");
+		AppInfo.Version.Should().Be(expected);
+	}
+
+	[Fact]
+	public void UserAgent_IsProductSlashVersion()
+	{
+		AppInfo.UserAgent.Should().Be($"MtgCsvHelper/{AppInfo.Version}");
+	}
+}

--- a/MtgCsvHelper/AppInfo.cs
+++ b/MtgCsvHelper/AppInfo.cs
@@ -1,0 +1,16 @@
+using System.Reflection;
+
+namespace MtgCsvHelper;
+
+// Single source of truth for app-wide identity strings (version, User-Agent).
+// Read once from this assembly's metadata at static-init time; the underlying value
+// comes from <Version> in Directory.Build.props via MSBuild's auto-generated
+// AssemblyInformationalVersionAttribute.
+public static class AppInfo
+{
+	public static string Version { get; } = typeof(AppInfo).Assembly
+		.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+		.InformationalVersion ?? "unknown";
+
+	public static string UserAgent { get; } = $"MtgCsvHelper/{Version}";
+}

--- a/MtgCsvHelper/ServiceConfiguration.cs
+++ b/MtgCsvHelper/ServiceConfiguration.cs
@@ -16,7 +16,7 @@ public static class ServiceConfiguration
 		services.AddHttpClient<ScryfallApiClient>(client =>
 		{
 			client.BaseAddress = new Uri("https://api.scryfall.com/");
-			client.DefaultRequestHeaders.Add("User-Agent", "MtgCsvHelper/1.0.0");
+			client.DefaultRequestHeaders.Add("User-Agent", AppInfo.UserAgent);
 			client.DefaultRequestHeaders.Add("Accept", "application/json");
 
 		});

--- a/MtgCsvHelper/Services/CachedMtgApi.cs
+++ b/MtgCsvHelper/Services/CachedMtgApi.cs
@@ -28,7 +28,7 @@ public class CachedMtgApi : IMtgApi
 		BaseAddress = ScryfallApiClientConfig.GetDefault().ScryfallApiBaseAddress,
 		DefaultRequestHeaders =
 				{
-					{"User-Agent", "MtgCsvHelper/1.0.0"},
+					{"User-Agent", AppInfo.UserAgent},
 					{"Accept", "application/json"}
 				}
 	};


### PR DESCRIPTION
The 1.1.0 release exposed a bug: \`Version\` lived in three places independently maintained, and the bump only touched one. The deployed Blazor site has been advertising itself as \`MtgCsvHelper/1.0.0\` to Scryfall since the release.

## What changed

- **New \`Directory.Build.props\`** at repo root with a single \`<Version>\` entry. All \`.csproj\` files in the solution inherit it. MSBuild auto-derives \`AssemblyVersion\` / \`FileVersion\` / \`AssemblyInformationalVersionAttribute\` from this.
- **Removed \`<Version>\` from \`MtgCsvHelper.BlazorWebAssembly.csproj\`** — now inherited.
- **\`ServiceConfiguration.UserAgent\`** new constant, computed once from \`Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()\`. Both User-Agent strings (in \`ServiceConfiguration\` and \`CachedMtgApi.DEFAULT_CLIENT\`) now use it.

## Why \`InformationalVersion\` not \`Version.ToString(3)\`

\`Version\` (the type) has 4 components (Major.Minor.Build.Revision); \`.ToString(3)\` truncates to first 3 but throws \`ArgumentException\` if fewer than 3 are populated, and can't represent pre-release suffixes (\`1.2.0-beta\`). \`InformationalVersion\` is just a string, populated verbatim from \`<Version>\` in the csproj. Recommended pattern.

## Test plan

- [x] \`dotnet build\`: 0 errors, 0 warnings.
- [x] \`dotnet test\`: 89/89 (88 prior + 1 new \`ServiceConfigurationTests.UserAgent_*\` guarding against re-hardcoding).
- [x] After this lands and the next \`<Version>\` bump in \`Directory.Build.props\` happens, the User-Agent will track automatically — no separate strings to remember.

## Future bump procedure

Edit \`Directory.Build.props\`, change \`<Version>\`. That's it.