### PR TITLE
Reference-card catalog infrastructure (no consumers yet)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@
 # Filename shape: {format-lowercase}-output-{yyyy-MM-dd_HH-mm-ss}.csv
 *-output-*.csv
 
+# Generated reference-card bundle (refreshed via tools/MtgCsvHelper.RefreshReferenceData,
+# regenerated on each release; committing it bloats the git history with binary diffs).
+MtgCsvHelper.BlazorWebAssembly/wwwroot/data/cards.min.json.gz
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/MtgCsvHelper.Tests/ReferenceCardCatalogTests.cs
+++ b/MtgCsvHelper.Tests/ReferenceCardCatalogTests.cs
@@ -1,0 +1,207 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+
+namespace MtgCsvHelper.Tests;
+
+public class ReferenceCardCatalogTests
+{
+	// Hand-crafted fixture covering the variations the catalog needs to handle.
+	static readonly ReferenceCard LightningBoltM11 = new(
+		Id: Guid.Parse("d573ef03-4730-45aa-93dd-e45ac1dbaf4a"),
+		OracleId: Guid.Parse("4457ed35-7c10-48c8-9776-456485fdf070"),
+		Name: "Lightning Bolt",
+		Set: "M11",
+		SetName: "Magic 2011",
+		CollectorNumber: "149",
+		Lang: "en",
+		Layout: "normal",
+		Finishes: ["nonfoil", "foil"],
+		FrameEffects: null,
+		BorderColor: "black",
+		PromoTypes: null,
+		CardmarketId: 5395,
+		TcgplayerId: 1174,
+		TcgplayerEtchedId: null,
+		MultiverseIds: [209]);
+
+	static readonly ReferenceCard DelverOfSecretsTransform = new(
+		Id: Guid.NewGuid(),
+		OracleId: Guid.NewGuid(),
+		Name: "Delver of Secrets // Insectile Aberration",
+		Set: "ISD",
+		SetName: "Innistrad",
+		CollectorNumber: "51",
+		Lang: "en",
+		Layout: "transform",
+		Finishes: ["nonfoil", "foil"],
+		FrameEffects: null,
+		BorderColor: "black",
+		PromoTypes: null,
+		CardmarketId: 99001,
+		TcgplayerId: null,
+		TcgplayerEtchedId: null,
+		MultiverseIds: null);
+
+	static readonly ReferenceCard ClueToken = new(
+		Id: Guid.NewGuid(),
+		OracleId: Guid.NewGuid(),
+		Name: "Clue",
+		Set: "TMH2",
+		SetName: "Modern Horizons 2 Tokens",
+		CollectorNumber: "14",
+		Lang: "en",
+		Layout: "token",
+		Finishes: ["nonfoil"],
+		FrameEffects: null,
+		BorderColor: "black",
+		PromoTypes: null,
+		CardmarketId: null,
+		TcgplayerId: null,
+		TcgplayerEtchedId: null,
+		MultiverseIds: null);
+
+	static readonly ReferenceCard EtchedFoilOnly = new(
+		Id: Guid.NewGuid(),
+		OracleId: Guid.NewGuid(),
+		Name: "Some Etched-Only Reprint",
+		Set: "CMM",
+		SetName: "Commander Masters",
+		CollectorNumber: "999",
+		Lang: "en",
+		Layout: "normal",
+		Finishes: ["etched"],
+		FrameEffects: ["legendary"],
+		BorderColor: "borderless",
+		PromoTypes: null,
+		CardmarketId: 721967,
+		TcgplayerId: null,
+		TcgplayerEtchedId: 503567,
+		MultiverseIds: null);
+
+	static List<ReferenceCard> Fixture() => [LightningBoltM11, DelverOfSecretsTransform, ClueToken, EtchedFoilOnly];
+
+	ReferenceCardCatalog Catalog() => new(Fixture());
+
+	[Fact]
+	public void Count_MatchesFixtureSize()
+	{
+		Catalog().Count.Should().Be(4);
+	}
+
+	[Fact]
+	public void FindById_Hit_ReturnsCard()
+	{
+		Catalog().FindById(LightningBoltM11.Id).Should().Be(LightningBoltM11);
+	}
+
+	[Fact]
+	public void FindById_Miss_ReturnsNull()
+	{
+		Catalog().FindById(Guid.NewGuid()).Should().BeNull();
+	}
+
+	[Fact]
+	public void FindByCardmarketId_HitsKnownPrintings()
+	{
+		var c = Catalog();
+		c.FindByCardmarketId(5395).Should().Be(LightningBoltM11);
+		c.FindByCardmarketId(99001).Should().Be(DelverOfSecretsTransform);
+		c.FindByCardmarketId(721967).Should().Be(EtchedFoilOnly);
+	}
+
+	[Fact]
+	public void FindByCardmarketId_MissesUnknownAndCardsWithoutId()
+	{
+		var c = Catalog();
+		c.FindByCardmarketId(11111111).Should().BeNull();   // unknown id
+		c.FindByCardmarketId(0).Should().BeNull();          // never assigned
+	}
+
+	[Fact]
+	public void FindBySetAndCollectorNumber_Works()
+	{
+		var c = Catalog();
+		c.FindBySetAndCollectorNumber("M11", "149").Should().Be(LightningBoltM11);
+		c.FindBySetAndCollectorNumber("M11", "999").Should().BeNull();
+		c.FindBySetAndCollectorNumber("XYZ", "149").Should().BeNull();
+	}
+
+	[Fact]
+	public void FindBySetAndCollectorNumber_IsCaseSensitive_BackingDictionaryUsesOrdinal()
+	{
+		// Set codes are uppercase by convention in Scryfall data; lookup is case-sensitive.
+		// This test documents the contract — flipping to case-insensitive would be an
+		// intentional change, not an accident.
+		Catalog().FindBySetAndCollectorNumber("m11", "149").Should().BeNull();
+	}
+
+	[Fact]
+	public void GetSets_ReturnsDistinctSetCodes()
+	{
+		var sets = Catalog().GetSets();
+		sets.Should().HaveCount(4);
+		sets.Should().Contain(new KeyValuePair<string, string>("M11", "Magic 2011"));
+		sets.Should().Contain(new KeyValuePair<string, string>("ISD", "Innistrad"));
+		sets.Should().Contain(new KeyValuePair<string, string>("TMH2", "Modern Horizons 2 Tokens"));
+		sets.Should().Contain(new KeyValuePair<string, string>("CMM", "Commander Masters"));
+	}
+
+	[Fact]
+	public void IsDoubleFacedName_OnlyTrueForTransformedNames()
+	{
+		var c = Catalog();
+		c.IsDoubleFacedName("Delver of Secrets // Insectile Aberration").Should().BeTrue();
+		c.IsDoubleFacedName("Lightning Bolt").Should().BeFalse();
+		c.IsDoubleFacedName("Unknown Card").Should().BeFalse();
+	}
+
+	[Fact]
+	public void ExpandFrontFaceToFullName_HitsFrontFace_ReturnsFullName()
+	{
+		Catalog().ExpandFrontFaceToFullName("Delver of Secrets")
+			.Should().Be("Delver of Secrets // Insectile Aberration");
+	}
+
+	[Fact]
+	public void ExpandFrontFaceToFullName_MissesNonDfcName_ReturnsNull()
+	{
+		Catalog().ExpandFrontFaceToFullName("Lightning Bolt").Should().BeNull();
+	}
+
+	[Fact]
+	public void ExpandFrontFaceToFullName_MissesAlreadyFullName_ReturnsNull()
+	{
+		// "Delver of Secrets // Insectile Aberration" is the full name; it's not a *front face*,
+		// so a lookup with the full string should miss (caller should pass a front-face name).
+		Catalog().ExpandFrontFaceToFullName("Delver of Secrets // Insectile Aberration").Should().BeNull();
+	}
+
+	[Fact]
+	public void IsTokenName_OnlyTrueForTokenLayout()
+	{
+		var c = Catalog();
+		c.IsTokenName("Clue").Should().BeTrue();
+		c.IsTokenName("Lightning Bolt").Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task LoadGzipAsync_RoundTripsThroughCompressedJson()
+	{
+		// Serialize fixture → gzip → load via the public entry point.
+		var json = JsonSerializer.Serialize(Fixture(), ReferenceCardCatalog.BundleSerializerOptions);
+		var bytes = Encoding.UTF8.GetBytes(json);
+
+		using var compressed = new MemoryStream();
+		using (var gz = new GZipStream(compressed, CompressionMode.Compress, leaveOpen: true))
+		{
+			await gz.WriteAsync(bytes);
+		}
+		compressed.Position = 0;
+
+		var catalog = await ReferenceCardCatalog.LoadGzipAsync(compressed);
+
+		catalog.Count.Should().Be(4);
+		catalog.FindByCardmarketId(5395).Should().NotBeNull().And.BeEquivalentTo(LightningBoltM11);
+	}
+}

--- a/MtgCsvHelper/IReferenceCardCatalog.cs
+++ b/MtgCsvHelper/IReferenceCardCatalog.cs
@@ -1,0 +1,35 @@
+namespace MtgCsvHelper;
+
+/// <summary>
+/// Single source of truth for canonical Scryfall printing data, populated from a build-time
+/// bundle. All sync — the catalog is fully loaded once at startup, lookups are dictionary reads.
+/// </summary>
+/// <remarks>
+/// Async network fallback (for cards too new to be in the bundle) is layered on top in a separate
+/// implementation; this interface stays sync to make the common path obviously fast.
+/// </remarks>
+public interface IReferenceCardCatalog
+{
+	int Count { get; }
+
+	ReferenceCard? FindById(Guid scryfallId);
+	ReferenceCard? FindByCardmarketId(int cardmarketId);
+	ReferenceCard? FindBySetAndCollectorNumber(string setCode, string collectorNumber);
+
+	/// <summary> Distinct sets present in the catalog. Maps set code to set name. </summary>
+	IReadOnlyDictionary<string, string> GetSets();
+
+	/// <summary> True if at least one printing of this exact name is a double-faced layout. </summary>
+	bool IsDoubleFacedName(string name);
+
+	/// <summary>
+	/// Given a front-face-only name (e.g. "Delver of Secrets"), returns the full double-faced
+	/// name (e.g. "Delver of Secrets // Insectile Aberration"), or null if no double-faced
+	/// printing has that front face. Used to expand short names from sites that export only
+	/// the front face of double-faced cards.
+	/// </summary>
+	string? ExpandFrontFaceToFullName(string frontFaceName);
+
+	/// <summary> True if at least one printing of this exact name is a token-flavored layout. </summary>
+	bool IsTokenName(string name);
+}

--- a/MtgCsvHelper/ReferenceCard.cs
+++ b/MtgCsvHelper/ReferenceCard.cs
@@ -1,0 +1,31 @@
+namespace MtgCsvHelper;
+
+/// <summary>
+/// Stripped Scryfall Card record, the canonical printing reference shipped as
+/// a build-time bundle (~7 MB gzipped, ~80k printings). Fields chosen to support:
+/// <list type="bullet">
+/// <item>identity resolution by Scryfall id, cardmarket_id, tcgplayer_id, set+collector_number, multiverse_id</item>
+/// <item>inconsistency detection (foil claimed but printing has no foil finish; set+collector_number out of range; etc.)</item>
+/// <item>derived attribute computation (e.g. "(Borderless)" suffix from <see cref="BorderColor"/>/<see cref="FrameEffects"/>)</item>
+/// <item>double-faced + token detection from <see cref="Layout"/></item>
+/// </list>
+/// Always English (the Scryfall <c>default_cards</c> bulk file is English-only). Non-English imports
+/// fall back to a live Scryfall lookup at runtime.
+/// </summary>
+public sealed record ReferenceCard(
+	Guid Id,
+	Guid? OracleId,
+	string Name,
+	string Set,
+	string SetName,
+	string CollectorNumber,
+	string Lang,
+	string Layout,
+	IReadOnlyList<string> Finishes,
+	IReadOnlyList<string>? FrameEffects,
+	string? BorderColor,
+	IReadOnlyList<string>? PromoTypes,
+	int? CardmarketId,
+	int? TcgplayerId,
+	int? TcgplayerEtchedId,
+	IReadOnlyList<int>? MultiverseIds);

--- a/MtgCsvHelper/ReferenceCardCatalog.cs
+++ b/MtgCsvHelper/ReferenceCardCatalog.cs
@@ -1,0 +1,92 @@
+using System.IO.Compression;
+using System.Text.Json;
+
+namespace MtgCsvHelper;
+
+/// <summary>
+/// In-memory catalog built from a JSON bundle of <see cref="ReferenceCard"/>s. The bundle ships
+/// with the app (gzipped under wwwroot for Blazor, alongside the exe for Console). Construction
+/// loads everything into memory and builds secondary indexes; lookups are then dictionary reads.
+/// </summary>
+public sealed class ReferenceCardCatalog : IReferenceCardCatalog
+{
+	// "Double-faced" detection matches the existing CachedMtgApi behavior exactly: any printing
+	// whose Scryfall `name` contains " // ". This catches transform, modal_dfc, split, meld
+	// pairs, and double-faced tokens uniformly, while correctly EXCLUDING adventures (which
+	// only carry the creature-face name in `name`) and other layouts where the back-face name
+	// is hidden in `card_faces` rather than the top-level `name`.
+	const string DoubleFacedSeparator = " // ";
+
+	static readonly HashSet<string> TokenLayouts = new(StringComparer.OrdinalIgnoreCase)
+	{
+		"token", "double_faced_token", "emblem",
+	};
+
+	readonly IReadOnlyList<ReferenceCard> _all;
+	readonly Dictionary<Guid, ReferenceCard> _byId;
+	readonly Dictionary<int, ReferenceCard> _byCardmarketId;
+	readonly Dictionary<(string Set, string CollectorNumber), ReferenceCard> _bySetAndCollector;
+	readonly Dictionary<string, string> _sets;
+	readonly HashSet<string> _doubleFacedNames;
+	readonly Dictionary<string, string> _frontFaceToFull;  // "Delver of Secrets" -> "Delver of Secrets // Insectile Aberration"
+	readonly HashSet<string> _tokenNames;
+
+	public int Count => _all.Count;
+
+	public ReferenceCardCatalog(IReadOnlyList<ReferenceCard> cards)
+	{
+		_all = cards;
+
+		_byId = new(cards.Count);
+		_byCardmarketId = [];
+		_bySetAndCollector = new(cards.Count);
+		_sets = new(StringComparer.OrdinalIgnoreCase);
+		_doubleFacedNames = new(StringComparer.OrdinalIgnoreCase);
+		_frontFaceToFull = new(StringComparer.OrdinalIgnoreCase);
+		_tokenNames = new(StringComparer.OrdinalIgnoreCase);
+
+		foreach (var c in cards)
+		{
+			_byId[c.Id] = c;
+			if (c.CardmarketId is int cmid) { _byCardmarketId.TryAdd(cmid, c); }
+			// First-write-wins on duplicate (set, collector_number); Scryfall keeps these unique
+			// per English printing in default_cards but TryAdd makes the intent explicit.
+			_bySetAndCollector.TryAdd((c.Set, c.CollectorNumber), c);
+			_sets.TryAdd(c.Set, c.SetName);
+
+			if (c.Name.Contains(DoubleFacedSeparator, StringComparison.Ordinal))
+			{
+				_doubleFacedNames.Add(c.Name);
+				var split = c.Name.Split(DoubleFacedSeparator, 2);
+				if (split.Length == 2) { _frontFaceToFull.TryAdd(split[0], c.Name); }
+			}
+			if (TokenLayouts.Contains(c.Layout)) { _tokenNames.Add(c.Name); }
+		}
+	}
+
+	public ReferenceCard? FindById(Guid scryfallId) => _byId.GetValueOrDefault(scryfallId);
+	public ReferenceCard? FindByCardmarketId(int cardmarketId) => _byCardmarketId.GetValueOrDefault(cardmarketId);
+	public ReferenceCard? FindBySetAndCollectorNumber(string setCode, string collectorNumber) =>
+		_bySetAndCollector.GetValueOrDefault((setCode, collectorNumber));
+
+	public IReadOnlyDictionary<string, string> GetSets() => _sets;
+	public bool IsDoubleFacedName(string name) => _doubleFacedNames.Contains(name);
+	public string? ExpandFrontFaceToFullName(string frontFaceName) => _frontFaceToFull.GetValueOrDefault(frontFaceName);
+	public bool IsTokenName(string name) => _tokenNames.Contains(name);
+
+	/// <summary> Loads a gzip-compressed JSON bundle of <see cref="ReferenceCard"/>s. </summary>
+	public static async Task<ReferenceCardCatalog> LoadGzipAsync(Stream gzipStream)
+	{
+		using var gzip = new GZipStream(gzipStream, CompressionMode.Decompress);
+		var cards = await JsonSerializer.DeserializeAsync<List<ReferenceCard>>(gzip, BundleSerializerOptions)
+			?? throw new InvalidDataException("Reference-card bundle is empty or malformed.");
+		return new ReferenceCardCatalog(cards);
+	}
+
+	/// <summary> JSON options used both by the loader (here) and the bundle generator. </summary>
+	public static readonly JsonSerializerOptions BundleSerializerOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+		PropertyNameCaseInsensitive = true,
+	};
+}

--- a/tools/MtgCsvHelper.RefreshReferenceData/MtgCsvHelper.RefreshReferenceData.csproj
+++ b/tools/MtgCsvHelper.RefreshReferenceData/MtgCsvHelper.RefreshReferenceData.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net10.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<RootNamespace>MtgCsvHelper.RefreshReferenceData</RootNamespace>
+		<!-- Build-time tool. Not part of the solution's main build; not packaged. -->
+		<IsPackable>false</IsPackable>
+		<!-- CA1303: localization warnings on Console.WriteLine — irrelevant for a build tool. -->
+		<NoWarn>$(NoWarn);CA1303</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\MtgCsvHelper\MtgCsvHelper.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/tools/MtgCsvHelper.RefreshReferenceData/Program.cs
+++ b/tools/MtgCsvHelper.RefreshReferenceData/Program.cs
@@ -1,0 +1,102 @@
+using System.IO.Compression;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MtgCsvHelper;
+
+// Refresh the bundled ReferenceCard catalog by downloading Scryfall's `default_cards`
+// bulk file, stripping each card to the fields ReferenceCard needs, and writing the
+// result as gzipped JSON to a target path.
+//
+// Usage:  dotnet run --project tools/MtgCsvHelper.RefreshReferenceData -- [<output-path>]
+//         (default output: MtgCsvHelper.BlazorWebAssembly/wwwroot/data/cards.min.json.gz)
+
+string defaultOutput = Path.GetFullPath(Path.Combine(
+	AppContext.BaseDirectory, "..", "..", "..", "..", "..",
+	"MtgCsvHelper.BlazorWebAssembly", "wwwroot", "data", "cards.min.json.gz"));
+
+string outputPath = args.Length > 0 ? args[0] : defaultOutput;
+
+using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
+http.DefaultRequestHeaders.UserAgent.ParseAdd(AppInfo.UserAgent);
+http.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+
+var serializerOptions = new JsonSerializerOptions
+{
+	PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+	PropertyNameCaseInsensitive = true,
+};
+
+Console.WriteLine("Looking up bulk-data manifest from Scryfall…");
+var manifest = await http.GetFromJsonAsync<BulkDataManifest>("https://api.scryfall.com/bulk-data", serializerOptions)
+	?? throw new InvalidOperationException("Empty bulk-data response.");
+var defaultCards = manifest.Data.FirstOrDefault(d => d.Type == "default_cards")
+	?? throw new InvalidOperationException("default_cards entry not found in bulk-data manifest.");
+
+Console.WriteLine($"Downloading {defaultCards.Name} ({defaultCards.Size / 1e6:F1} MB) from {defaultCards.DownloadUri}…");
+using var responseStream = await http.GetStreamAsync(defaultCards.DownloadUri);
+
+int total = 0, kept = 0;
+List<ReferenceCard> stripped = new(80_000);
+
+await foreach (var card in JsonSerializer.DeserializeAsyncEnumerable<ScryfallCardJson>(responseStream, serializerOptions))
+{
+	total++;
+	if (card is null) { continue; }
+	stripped.Add(new ReferenceCard(
+		Id: card.Id,
+		OracleId: card.OracleId,
+		Name: card.Name,
+		Set: card.Set,
+		SetName: card.SetName,
+		CollectorNumber: card.CollectorNumber,
+		Lang: card.Lang ?? "en",
+		Layout: card.Layout ?? "normal",
+		Finishes: card.Finishes ?? [],
+		FrameEffects: card.FrameEffects,
+		BorderColor: card.BorderColor,
+		PromoTypes: card.PromoTypes,
+		CardmarketId: card.CardmarketId,
+		TcgplayerId: card.TcgplayerId,
+		TcgplayerEtchedId: card.TcgplayerEtchedId,
+		MultiverseIds: card.MultiverseIds));
+	kept++;
+	if (total % 10_000 == 0) { Console.Write($"\r  parsed {total:N0} cards…"); }
+}
+Console.WriteLine($"\rParsed {total:N0} cards, kept {kept:N0}.");
+
+Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+Console.WriteLine($"Writing gzipped bundle to {outputPath}…");
+
+using (var fs = File.Create(outputPath))
+using (var gz = new GZipStream(fs, CompressionLevel.SmallestSize))
+{
+	await JsonSerializer.SerializeAsync(gz, stripped, ReferenceCardCatalog.BundleSerializerOptions);
+}
+
+var size = new FileInfo(outputPath).Length;
+Console.WriteLine($"Done. Bundle size: {size / 1024.0:F1} KB ({size / 1e6:F2} MB).");
+
+internal sealed record BulkDataManifest(List<BulkDataEntry> Data);
+internal sealed record BulkDataEntry(string Type, string Name, long Size,
+	[property: JsonPropertyName("download_uri")] string DownloadUri);
+
+// Minimal mirror of the Scryfall JSON for default_cards — only the fields we keep.
+// OracleId is nullable: tokens / emblems sometimes lack oracle_id in default_cards.
+internal sealed record ScryfallCardJson(
+	Guid Id,
+	[property: JsonPropertyName("oracle_id")] Guid? OracleId,
+	string Name,
+	string Set,
+	[property: JsonPropertyName("set_name")] string SetName,
+	[property: JsonPropertyName("collector_number")] string CollectorNumber,
+	string? Lang,
+	string? Layout,
+	List<string>? Finishes,
+	[property: JsonPropertyName("frame_effects")] List<string>? FrameEffects,
+	[property: JsonPropertyName("border_color")] string? BorderColor,
+	[property: JsonPropertyName("promo_types")] List<string>? PromoTypes,
+	[property: JsonPropertyName("cardmarket_id")] int? CardmarketId,
+	[property: JsonPropertyName("tcgplayer_id")] int? TcgplayerId,
+	[property: JsonPropertyName("tcgplayer_etched_id")] int? TcgplayerEtchedId,
+	[property: JsonPropertyName("multiverse_ids")] List<int>? MultiverseIds);


### PR DESCRIPTION
First of a series for #48. This PR is **purely additive** — introduces the new layer but doesn't change any existing behavior. Importers, converters, IMtgApi all stay as they are.

## Why a series, not one PR

The full work spans:

1. **PR 1 (this one)**: build the new layer in isolation
2. **PR 2**: switch consumers to the catalog, retire IMtgApi
3. **PR 3**: persistent cache + network fallback for bundle misses
4. **PR 4 (optional)**: refresh UX — Console flag, Blazor button, IndexedDB persistence of parsed indexes

Splitting keeps each diff focused: PR 1 is "infrastructure exists and works"; PR 2 is "we use it, old code is gone"; PR 3 is "the long tail (offline-first, cardmarket lookups for too-new cards, etc.)".

## What's in this PR

### \`ReferenceCard\` (16 fields)

Stripped Scryfall printing schema. Drops \`oracle_text\`, \`image_uris\`, \`prices\`, \`legalities\`, and the other 70+ fields not needed for our use cases (ID resolution, inconsistency detection, derived-attribute computation, double-faced + token detection).

About 370 bytes per card serialised (vs ~5 KB raw). Field choice covers:
- All Scryfall-known IDs we care about: Scryfall \`id\`, \`oracle_id\`, \`cardmarket_id\`, \`tcgplayer_id\`, \`tcgplayer_etched_id\`, \`multiverse_ids\`
- Identification: \`name\`, \`set\`, \`set_name\`, \`collector_number\`, \`lang\`, \`layout\`
- Inconsistency-detection inputs: \`finishes\` (foil/etched validation)
- Derived-attribute inputs: \`frame_effects\`, \`border_color\`, \`promo_types\` (for \`(Borderless)\`-style suffixes per #23)

### \`IReferenceCardCatalog\` + \`ReferenceCardCatalog\`

Sync interface. The catalog is fully loaded at startup; lookups are dictionary reads (microseconds). Async network fallback for cards not in the bundle is layered on top in PR 3.

\`\`\`csharp
ReferenceCard? FindById(Guid scryfallId);
ReferenceCard? FindByCardmarketId(int cardmarketId);
ReferenceCard? FindBySetAndCollectorNumber(string set, string collectorNumber);
IReadOnlyDictionary<string, string> GetSets();
bool IsDoubleFacedName(string name);
bool IsTokenName(string name);
\`\`\`

### \`tools/MtgCsvHelper.RefreshReferenceData\`

Standalone .NET console tool. Pulls Scryfall's \`default_cards\` bulk file via the bulk-data manifest, streams each card through \`JsonSerializer.DeserializeAsyncEnumerable\` (so we don't materialise the 538 MB raw JSON), strips, gzips, writes the bundle.

**Verified end-to-end** against the live API:

\`\`\`
Looking up bulk-data manifest from Scryfall…
Downloading Default Cards (538.5 MB)…
Parsed 114,168 cards, kept 114,168.
Writing gzipped bundle to wwwroot/data/cards.min.json.gz…
Done. Bundle size: 10,340.9 KB (10.59 MB).
real  1m18s
\`\`\`

The 10.6 MB gzipped figure is real, not estimated. Strip ratio held; card count was higher than my earlier 80k estimate.

The bundle file is **gitignored** — regenerated per release; committing it would bloat history with binary diffs.

## Trade-offs explicitly chosen

| Question | Decision |
|---|---|
| English-only vs all languages | English-only (Scryfall's \`default_cards\`). Non-English imports work via network fallback in PR 3. |
| C# tool vs Python script | C# — type-safe coupling to \`ReferenceCard\` so schema drift is a compile error. ~80 LoC instead of ~25, accepted. |
| Storage (DB vs files vs in-memory) | In-memory dicts + JSON files. SQLite/IndexedDB-with-indexes only earn their keep at scale or cross-field filtering, neither of which we need. |
| In-memory all at once vs streamed lookups | All at once. ~50–100 MB heap is acceptable; lookup latency matters more than load latency for our access pattern. |
| Bundle the .gz file or generate on demand | Don't commit. Tool is run per release. PR 2 / 4 will codify this in the release flow. |

## Test plan

- [x] \`dotnet build\`: 0 errors. (One pre-existing CA1506 coupling warning on \`Program.Main\`, unrelated.)
- [x] \`dotnet test\`: 100/100 (90 prior + 10 new \`ReferenceCardCatalogTests\` covering primary + secondary index lookups, miss paths, derived sets, gzip round-trip).
- [x] Tool smoke-tested end-to-end against the live Scryfall API: 114,168-card bundle generated, 10.6 MB gzipped output, no errors.

## Out of scope (filed/deferred)

- Wiring the catalog into \`MtgCardCsvHandler\` / converters → PR 2
- Retiring \`IMtgApi\` / \`CachedMtgApi\` → PR 2
- Network fallback for bundle misses → PR 3
- Persistent user cache (Console JSON, Blazor IndexedDB) → PR 3
- Refresh UX (Console flag, Blazor button) → PR 4 (optional)