### PR TITLE
Fix auto-review: inject PR number into prompt

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,8 +57,15 @@ jobs:
           # Enabled so we can debug why Claude posts nothing despite running successfully (issue: 2 consecutive PRs).
           # Safe for our review prompts: no secrets in the input. Disable once auto-review is reliably commenting.
           show_full_output: true
+          # Inject the PR number explicitly. Without this the agent intermittently can't infer
+          # which PR to review and falls back to AskUserQuestion, which terminates silently in CI.
           prompt: |
-            Please review this pull request for:
+            Review pull request #${{ github.event.pull_request.number }} on ${{ github.repository }}.
+
+            Fetch the diff with: gh pr diff ${{ github.event.pull_request.number }}
+            Fetch metadata with: gh pr view ${{ github.event.pull_request.number }}
+
+            Review for:
             - Code quality and .NET best practices
             - Potential bugs or issues
             - Security implications


### PR DESCRIPTION
## Summary

Fixes intermittent silent failures of the `claude-auto-review` workflow. The previous prompt didn't tell the agent which PR to review, so it had to infer from env/git context. When inference failed, the agent fell back to `AskUserQuestion`, which terminates silently in non-interactive CI — workflow shows green but posts no review (caught on PRs #51, #54).

This passes `github.event.pull_request.number` directly into the prompt and spells out the `gh` commands the agent should run.

## Why this is its own PR

GitHub validates that workflow files on a PR match the default branch — otherwise the OIDC token exchange fails with 401. When I tried bundling this fix into PR #54, the workflow file diverged from `develop` and PR #54's auto-review started returning 401 instead of running. So this fix has to land on `develop` first; after merging, PR #54 will pick it up on rebase.

## Test plan

- [ ] Auto-review on this PR will likely either fail (workflow ≠ develop) or succeed using the OLD prompt — that's expected and not a blocker. Manual review.
- [ ] After merging, rebase PR #54 on `develop` and verify the next auto-review run uses the new prompt and posts comments.