### PR TITLE
PR 3 of #48: catalog-first Cardmarket resolution

### DIFF
--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -1,6 +1,6 @@
 @page "/"
 @inject IConfiguration Config
-@inject IMtgApi Api
+@inject ICardmarketResolver Resolver
 @inject IReferenceCardCatalog Catalog
 @inject IJSRuntime JS
 @using Serilog
@@ -158,8 +158,8 @@
 			await _csvFile!.OpenReadStream(maxAllowedSize: MaxFileSize).CopyToAsync(csvStream);
 			csvStream.Position = 0;
 
-			var reader = new MtgCardCsvHandler(Catalog, Api, Config, _selectedInputFormat);
-			var writer = new MtgCardCsvHandler(Catalog, Api, Config, _selectedOutputFormat);
+			var reader = new MtgCardCsvHandler(Catalog, Resolver, Config, _selectedInputFormat);
+			var writer = new MtgCardCsvHandler(Catalog, Resolver, Config, _selectedOutputFormat);
 
 			var result = await reader.ParseCollectionCsvAsync(csvStream);
 			_summary = result.Collection.GenerateSummary();

--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -133,6 +133,9 @@
 	private string? _resultFileName;
 	private MemoryStream? _resultStream;
 
+	// Cancelled on component teardown to abort any in-flight Scryfall lookup.
+	private readonly CancellationTokenSource _cts = new();
+
 	private async Task HandleFileUpload(InputFileChangeEventArgs e)
 	{
 		// TODO GetMultipleFiles() support
@@ -161,7 +164,7 @@
 			var reader = new MtgCardCsvHandler(Catalog, Resolver, Config, _selectedInputFormat);
 			var writer = new MtgCardCsvHandler(Catalog, Resolver, Config, _selectedOutputFormat);
 
-			var result = await reader.ParseCollectionCsvAsync(csvStream);
+			var result = await reader.ParseCollectionCsvAsync(csvStream, _cts.Token);
 			_summary = result.Collection.GenerateSummary();
 			_issues = result.Issues.ToList();
 
@@ -226,6 +229,8 @@
 
 	public void Dispose()
 	{
+		_cts.Cancel();
+		_cts.Dispose();
 		_resultStream?.Dispose();
 	}
 }

--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -183,6 +183,11 @@
 			var missing = hex.InvalidHeaders.SelectMany(h => h.Names).Distinct().ToList();
 			_headerError = $"This doesn't look like a valid {_selectedInputFormat} CSV — missing required column(s): {string.Join(", ", missing)}. Did you select the correct input format?";
 		}
+		catch (OperationCanceledException)
+		{
+			// Component torn down mid-parse — silent abort, no UI update needed.
+			return;
+		}
 		catch (Exception ex)
 		{
 			_summary = $"Unexpected error converting file: {ex.Message}";

--- a/MtgCsvHelper.Console/Program.cs
+++ b/MtgCsvHelper.Console/Program.cs
@@ -40,7 +40,7 @@ using IHost host = builder.Build();
 var config = host.Services.GetRequiredService<IConfiguration>();
 Log.Logger = new LoggerConfiguration().ReadFrom.Configuration(config).CreateLogger();
 
-var api = host.Services.GetRequiredService<IMtgApi>();
+var resolver = host.Services.GetRequiredService<ICardmarketResolver>();
 Log.Information("Loaded reference catalog: {Count:N0} printings.", catalog.Count);
 
 Parser.Default.ParseArguments<CommandLineOptions>(args)
@@ -60,8 +60,8 @@ void RunWithOptions(CommandLineOptions opts)
 		return;
 	}
 
-	var reader = new MtgCardCsvHandler(catalog, api, config, opts.InputFormat);
-	var writer = new MtgCardCsvHandler(catalog, api, config, opts.OutputFormat);
+	var reader = new MtgCardCsvHandler(catalog, resolver, config, opts.InputFormat);
+	var writer = new MtgCardCsvHandler(catalog, resolver, config, opts.OutputFormat);
 
 	List<PhysicalMtgCard> cardsFound = [];
 

--- a/MtgCsvHelper.Tests/BaseTest.cs
+++ b/MtgCsvHelper.Tests/BaseTest.cs
@@ -19,5 +19,5 @@ public class ApiBaseTest(CatalogFixture fixture, ITestOutputHelper output, LogEv
 	: BaseTest(output, level)
 {
 	protected readonly IReferenceCardCatalog _catalog = fixture.Catalog;
-	protected readonly MtgCsvHelper.Services.IMtgApi _api = fixture.Api;
+	protected readonly MtgCsvHelper.Services.ICardmarketResolver _resolver = fixture.Resolver;
 }

--- a/MtgCsvHelper.Tests/CardmarketResolverTests.cs
+++ b/MtgCsvHelper.Tests/CardmarketResolverTests.cs
@@ -14,7 +14,7 @@ public class CardmarketResolverTests(CatalogFixture fixture, ITestOutputHelper o
 		public List<int> CallsReceived { get; } = [];
 		public IReadOnlyDictionary<int, ReferenceCard> NextResponse { get; set; } = new Dictionary<int, ReferenceCard>();
 
-		public Task<IReadOnlyDictionary<int, ReferenceCard>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds)
+		public Task<IReadOnlyDictionary<int, ReferenceCard>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds, CancellationToken ct = default)
 		{
 			CallsReceived.AddRange(cardmarketIds);
 

--- a/MtgCsvHelper.Tests/CardmarketResolverTests.cs
+++ b/MtgCsvHelper.Tests/CardmarketResolverTests.cs
@@ -85,6 +85,7 @@ public class CardmarketResolverTests(CatalogFixture fixture, ITestOutputHelper o
 		var resolved = await resolver.ResolveAsync([hitId, missId]);
 
 		spy.CallsReceived.Should().BeEquivalentTo([missId], "the catalog hit must not be passed to the API");
+		resolved.Should().HaveCount(1);
 		resolved.Should().ContainKey(hitId);
 		resolved.Should().NotContainKey(missId);
 	}

--- a/MtgCsvHelper.Tests/CardmarketResolverTests.cs
+++ b/MtgCsvHelper.Tests/CardmarketResolverTests.cs
@@ -1,0 +1,91 @@
+using MtgCsvHelper.Services;
+
+namespace MtgCsvHelper.Tests;
+
+[Collection(CatalogCollection.Name)]
+public class CardmarketResolverTests(CatalogFixture fixture, ITestOutputHelper output) : ApiBaseTest(fixture, output)
+{
+	/// <summary>
+	/// Spy IMtgApi: never expected to be called in catalog-hit tests; if it is, the spy
+	/// records the invocation so the test can assert on it.
+	/// </summary>
+	sealed class SpyMtgApi : IMtgApi
+	{
+		public List<int> CallsReceived { get; } = [];
+		public IReadOnlyDictionary<int, ReferenceCard> NextResponse { get; set; } = new Dictionary<int, ReferenceCard>();
+
+		public Task<IReadOnlyDictionary<int, ReferenceCard>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds)
+		{
+			CallsReceived.AddRange(cardmarketIds);
+
+			return Task.FromResult(NextResponse);
+		}
+	}
+
+	[Fact]
+	public async Task Resolve_IdInCatalog_ReturnsCatalogEntry_WithoutCallingApi()
+	{
+		// 266380 (Putrid Leech, Conflux) is present in the cardmarket sample CSV and in the bundled catalog.
+		var spy = new SpyMtgApi();
+		var resolver = new CardmarketResolver(_catalog, spy);
+
+		var resolved = await resolver.ResolveAsync([266380]);
+
+		resolved.Should().ContainKey(266380);
+		resolved[266380].Name.Should().Be("Putrid Leech");
+		spy.CallsReceived.Should().BeEmpty("catalog hits must not trigger network egress");
+	}
+
+	[Fact]
+	public async Task Resolve_IdNotInCatalog_FallsBackToApi_WithExactMissingId()
+	{
+		// 99999999 is far above any real cardmarket_id; guaranteed catalog miss.
+		const int missingId = 99999999;
+		var cannedCard = new ReferenceCard(
+			Id: Guid.NewGuid(),
+			OracleId: null,
+			Name: "Canned Card",
+			Set: "TST",
+			SetName: "Test Set",
+			CollectorNumber: "1",
+			Lang: "en",
+			Layout: "normal",
+			Finishes: ["nonfoil"],
+			FrameEffects: null,
+			BorderColor: null,
+			PromoTypes: null,
+			CardmarketId: missingId,
+			TcgplayerId: null,
+			TcgplayerEtchedId: null,
+			MultiverseIds: null);
+		var spy = new SpyMtgApi
+		{
+			NextResponse = new Dictionary<int, ReferenceCard> { [missingId] = cannedCard }
+		};
+		var resolver = new CardmarketResolver(_catalog, spy);
+
+		var resolved = await resolver.ResolveAsync([missingId]);
+
+		spy.CallsReceived.Should().BeEquivalentTo([missingId], "the missing id must reach the API exactly once");
+		resolved.Should().ContainKey(missingId);
+		resolved[missingId].Name.Should().Be("Canned Card");
+	}
+
+	[Fact]
+	public async Task Resolve_MixedHitsAndMisses_OnlyMissesReachTheApi()
+	{
+		const int hitId = 266380;             // catalog hit
+		const int missId = 99999999;          // catalog miss
+		var spy = new SpyMtgApi
+		{
+			NextResponse = new Dictionary<int, ReferenceCard>() // miss stays unresolved
+		};
+		var resolver = new CardmarketResolver(_catalog, spy);
+
+		var resolved = await resolver.ResolveAsync([hitId, missId]);
+
+		spy.CallsReceived.Should().BeEquivalentTo([missId], "the catalog hit must not be passed to the API");
+		resolved.Should().ContainKey(hitId);
+		resolved.Should().NotContainKey(missId);
+	}
+}

--- a/MtgCsvHelper.Tests/CardmarketTests.cs
+++ b/MtgCsvHelper.Tests/CardmarketTests.cs
@@ -13,7 +13,7 @@ public class CardmarketTests(CatalogFixture fixture, ITestOutputHelper output) :
 	MtgCardCsvHandler Handler() => new(_catalog, _resolver, _config, "CARDMARKET");
 
 	[Fact]
-	public async Task ParseSample_ResolvesAllFiveCardsViaScryfall()
+	public async Task ParseSample_ResolvesAllFiveCardsFromCatalog()
 	{
 		var result = await Handler().ParseCollectionCsvAsync(SamplePath);
 

--- a/MtgCsvHelper.Tests/CardmarketTests.cs
+++ b/MtgCsvHelper.Tests/CardmarketTests.cs
@@ -10,7 +10,7 @@ public class CardmarketTests(CatalogFixture fixture, ITestOutputHelper output) :
 
 	static MemoryStream CsvStream(string csv) => new(Encoding.UTF8.GetBytes(csv));
 
-	MtgCardCsvHandler Handler() => new(_catalog, _api, _config, "CARDMARKET");
+	MtgCardCsvHandler Handler() => new(_catalog, _resolver, _config, "CARDMARKET");
 
 	[Fact]
 	public async Task ParseSample_ResolvesAllFiveCardsViaScryfall()

--- a/MtgCsvHelper.Tests/CatalogFixture.cs
+++ b/MtgCsvHelper.Tests/CatalogFixture.cs
@@ -4,15 +4,16 @@ using Serilog;
 namespace MtgCsvHelper.Tests;
 
 /// <summary>
-/// Loads the bundled reference catalog once for the entire test run, plus a fresh
-/// <see cref="IMtgApi"/> for the cardmarket-fallback path. Tests that don't need either
-/// can stick with <see cref="BaseTest"/>; tests that touch handlers or the catalog
-/// extend <see cref="ApiBaseTest"/>.
+/// Loads the bundled reference catalog once for the entire test run, plus an
+/// <see cref="ICardmarketResolver"/> wired over a real <see cref="CachedMtgApi"/> for the
+/// cardmarket-fallback path. Tests that don't need either can stick with <see cref="BaseTest"/>;
+/// tests that touch handlers or the catalog extend <see cref="ApiBaseTest"/>.
 /// </summary>
 public class CatalogFixture : IAsyncLifetime
 {
 	public IReferenceCardCatalog Catalog { get; private set; } = null!;
 	public IMtgApi Api { get; private set; } = null!;
+	public ICardmarketResolver Resolver { get; private set; } = null!;
 
 	public async Task InitializeAsync()
 	{
@@ -33,10 +34,12 @@ public class CatalogFixture : IAsyncLifetime
 		await using var fs = File.OpenRead(bundlePath);
 		Catalog = await ReferenceCardCatalog.LoadGzipAsync(fs);
 
-		// Note: Api makes live Scryfall calls for cardmarket-id resolution (the only
-		// network path still owned by IMtgApi). Tests that exercise it (CardmarketTests)
-		// remain integration-flavored. Catalog-backed paths are fully offline.
+		// Note: Api makes live Scryfall calls for catalog-miss cardmarket_ids (the only
+		// network path still owned by IMtgApi). Tests that exercise it through the resolver
+		// (CardmarketTests with the sample CSV) remain integration-flavored only when the
+		// sample ids aren't in the bundle; if they are, the resolver short-circuits.
 		Api = new CachedMtgApi();
+		Resolver = new CardmarketResolver(Catalog, Api);
 	}
 
 	public Task DisposeAsync() => Task.CompletedTask;

--- a/MtgCsvHelper.Tests/CatalogFixture.cs
+++ b/MtgCsvHelper.Tests/CatalogFixture.cs
@@ -12,7 +12,7 @@ namespace MtgCsvHelper.Tests;
 public class CatalogFixture : IAsyncLifetime
 {
 	public IReferenceCardCatalog Catalog { get; private set; } = null!;
-	public IMtgApi Api { get; private set; } = null!;
+	IMtgApi Api { get; set; } = null!;
 	public ICardmarketResolver Resolver { get; private set; } = null!;
 
 	public async Task InitializeAsync()

--- a/MtgCsvHelper.Tests/CatalogFixture.cs
+++ b/MtgCsvHelper.Tests/CatalogFixture.cs
@@ -12,7 +12,7 @@ namespace MtgCsvHelper.Tests;
 public class CatalogFixture : IAsyncLifetime
 {
 	public IReferenceCardCatalog Catalog { get; private set; } = null!;
-	IMtgApi Api { get; set; } = null!;
+	private IMtgApi Api { get; set; } = null!;
 	public ICardmarketResolver Resolver { get; private set; } = null!;
 
 	public async Task InitializeAsync()

--- a/MtgCsvHelper.Tests/DeckFormatTests.cs
+++ b/MtgCsvHelper.Tests/DeckFormatTests.cs
@@ -84,7 +84,7 @@ public class DeckFormatTests(CatalogFixture fixture, ITestOutputHelper output) :
 	[InlineData("DECKBOX")]
 	public void StreamRoundTripTest(string deckFormatName)
 	{
-		var handler = new MtgCardCsvHandler(_catalog, _api, _config, deckFormatName);
+		var handler = new MtgCardCsvHandler(_catalog, _resolver, _config, deckFormatName);
 		var original = new List<PhysicalMtgCard>
 		{
 			new() { Count = 2, Printing = new Card { Name = "Lightning Bolt", Set = "M11", SetName = "Magic 2011", CollectorNumber = "149" } }
@@ -104,7 +104,7 @@ public class DeckFormatTests(CatalogFixture fixture, ITestOutputHelper output) :
 	[Fact]
 	public void ParseCollectionCsv_WithCardKingdomAsInput_Throws()
 	{
-		var handler = new MtgCardCsvHandler(_catalog, _api, _config, "CARDKINGDOM");
+		var handler = new MtgCardCsvHandler(_catalog, _resolver, _config, "CARDKINGDOM");
 		var act = () => handler.ParseCollectionCsv(new MemoryStream("a,b,c\n"u8.ToArray()));
 		act.Should().Throw<InvalidOperationException>().WithMessage("*write-only*");
 	}

--- a/MtgCsvHelper.Tests/FaultToleranceTests.cs
+++ b/MtgCsvHelper.Tests/FaultToleranceTests.cs
@@ -9,7 +9,7 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 	const string MoxHeader = "Count,Name,Edition,Collector Number,Foil,Condition,Language,Purchase Price";
 
 	static MemoryStream CsvStream(string csv) => new(Encoding.UTF8.GetBytes(csv));
-	MtgCardCsvHandler Handler(string format = "MOXFIELD") => new(_catalog, _api, _config, format);
+	MtgCardCsvHandler Handler(string format = "MOXFIELD") => new(_catalog, _resolver, _config, format);
 
 	[Fact]
 	public void HappyPath_AllValid_ProducesCardsAndNoIssues()

--- a/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
+++ b/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
@@ -74,7 +74,7 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 		cards.Should().HaveCountGreaterThan(500);
 	}
 
-	MtgCardCsvHandler CreateHandler(string deckFormatName) => new(_catalog, _api, _config, deckFormatName);
+	MtgCardCsvHandler CreateHandler(string deckFormatName) => new(_catalog, _resolver, _config, deckFormatName);
 
 	static List<PhysicalMtgCard> GetReferenceCards(Currency currency)
 	{

--- a/MtgCsvHelper.Tests/ReferenceCardTests.cs
+++ b/MtgCsvHelper.Tests/ReferenceCardTests.cs
@@ -1,0 +1,99 @@
+namespace MtgCsvHelper.Tests;
+
+public class ReferenceCardTests
+{
+	[Fact]
+	public void CreateFromScryfall_AppliesDefaults_ForNullInputs()
+	{
+		// Null lang/layout/finishes is the empirically observed Scryfall shape for tokens, emblems,
+		// and some special printings. The factory has to substitute the canonical defaults; this test
+		// pins down each fallback so a future change to the factory can't silently drop one of them.
+		var input = new ScryfallCardJson(
+			Id: Guid.Empty,
+			OracleId: null,
+			Name: "Test",
+			Set: "TST",
+			SetName: "Test Set",
+			CollectorNumber: "1",
+			Lang: null,
+			Layout: null,
+			Finishes: null,
+			FrameEffects: null,
+			BorderColor: null,
+			PromoTypes: null,
+			CardmarketId: null,
+			TcgplayerId: null,
+			TcgplayerEtchedId: null,
+			MultiverseIds: null);
+
+		var result = ReferenceCard.CreateFromScryfall(input);
+
+		result.Lang.Should().Be("en");
+		result.Layout.Should().Be("normal");
+		result.Finishes.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void CreateFromScryfall_EmptyLangOrLayout_AlsoFallsBack()
+	{
+		// Distinct from the null case: empty-string lang/layout (rare but observed) also has to fall
+		// through to the canonical defaults — `??` alone wouldn't catch it.
+		var input = new ScryfallCardJson(
+			Id: Guid.Empty,
+			OracleId: null,
+			Name: "Test",
+			Set: "TST",
+			SetName: "Test Set",
+			CollectorNumber: "1",
+			Lang: "",
+			Layout: "",
+			Finishes: ["nonfoil"],
+			FrameEffects: null,
+			BorderColor: null,
+			PromoTypes: null,
+			CardmarketId: null,
+			TcgplayerId: null,
+			TcgplayerEtchedId: null,
+			MultiverseIds: null);
+
+		var result = ReferenceCard.CreateFromScryfall(input);
+
+		result.Lang.Should().Be("en");
+		result.Layout.Should().Be("normal");
+		result.Finishes.Should().BeEquivalentTo(["nonfoil"]);
+	}
+
+	[Fact]
+	public void CreateFromScryfall_PassesThroughNonDefaultedFields()
+	{
+		var input = new ScryfallCardJson(
+			Id: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+			OracleId: Guid.Parse("22222222-2222-2222-2222-222222222222"),
+			Name: "Lightning Bolt",
+			Set: "M11",
+			SetName: "Magic 2011",
+			CollectorNumber: "149",
+			Lang: "de",
+			Layout: "split",
+			Finishes: ["nonfoil", "foil"],
+			FrameEffects: ["showcase"],
+			BorderColor: "black",
+			PromoTypes: ["promo"],
+			CardmarketId: 5395,
+			TcgplayerId: 1174,
+			TcgplayerEtchedId: 999,
+			MultiverseIds: [209, 210]);
+
+		var result = ReferenceCard.CreateFromScryfall(input);
+
+		result.Lang.Should().Be("de");
+		result.Layout.Should().Be("split");
+		result.Finishes.Should().BeEquivalentTo(["nonfoil", "foil"]);
+		result.FrameEffects.Should().BeEquivalentTo(["showcase"]);
+		result.BorderColor.Should().Be("black");
+		result.CardmarketId.Should().Be(5395);
+		result.TcgplayerId.Should().Be(1174);
+		result.TcgplayerEtchedId.Should().Be(999);
+		result.MultiverseIds.Should().BeEquivalentTo([209, 210]);
+	}
+}

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -25,9 +25,9 @@ public class MtgCardCsvHandler
 	public ParseResult ParseCollectionCsv(string csvFilePath) => ParseCollectionCsvAsync(csvFilePath).GetAwaiter().GetResult();
 	public ParseResult ParseCollectionCsv(Stream csvStream) => ParseCollectionCsvAsync(csvStream).GetAwaiter().GetResult();
 
-	public Task<ParseResult> ParseCollectionCsvAsync(string csvFilePath) => ParseCollectionCsvAsync(File.OpenRead(csvFilePath));
+	public Task<ParseResult> ParseCollectionCsvAsync(string csvFilePath, CancellationToken ct = default) => ParseCollectionCsvAsync(File.OpenRead(csvFilePath), ct);
 
-	public async Task<ParseResult> ParseCollectionCsvAsync(Stream csvStream)
+	public async Task<ParseResult> ParseCollectionCsvAsync(Stream csvStream, CancellationToken ct = default)
 	{
 		Log.Information($"Parsing input format {_format} ...");
 		using var reader = new StreamReader(csvStream);
@@ -55,8 +55,10 @@ public class MtgCardCsvHandler
 		var rowNumbers = new List<int>(); // parallel to cards; needed for issue reporting in the post-parse enrichment step
 		var issues = new List<ImportIssue>();
 
+		// CsvHelper's ReadAsync doesn't take a CT, so cancellation is checked per-row instead.
 		while (await csv.ReadAsync())
 		{
+			ct.ThrowIfCancellationRequested();
 			// Skip rows that are blank or contain only delimiters/whitespace.
 			if (csv.Parser.Record is null || csv.Parser.Record.All(string.IsNullOrWhiteSpace))
 			{
@@ -97,7 +99,7 @@ public class MtgCardCsvHandler
 		}
 
 		// Post-parse enrichment: fill in stubbed cards (Cardmarket) by batched Scryfall lookup.
-		await EnrichByCardmarketIdAsync(cards, rowNumbers, issues);
+		await EnrichByCardmarketIdAsync(cards, rowNumbers, issues, ct);
 
 		var collection = new Collection { Name = $"Import {_format}, Date: {DateTime.Now}", Cards = cards };
 		Log.Debug(collection.GenerateSummary());
@@ -143,7 +145,7 @@ public class MtgCardCsvHandler
 	// For cards whose Printing was parsed as a stub (only CardMarketId set), batch-resolve the
 	// full Scryfall card by cardmarket_id and fill in name/set/setName/collectorNumber.
 	// IDs not found in Scryfall produce an ImportIssue.Warning per affected card.
-	async Task EnrichByCardmarketIdAsync(IList<PhysicalMtgCard> cards, IList<int> rowNumbers, List<ImportIssue> issues)
+	async Task EnrichByCardmarketIdAsync(IList<PhysicalMtgCard> cards, IList<int> rowNumbers, List<ImportIssue> issues, CancellationToken ct)
 	{
 		// CardMarketId is `int` (not `int?`) in the Scryfall library, so 0 acts as the "unset" sentinel —
 		// real cardmarket_ids are always positive in Scryfall data.
@@ -160,7 +162,7 @@ public class MtgCardCsvHandler
 		if (pending.Count == 0) return;
 
 		var ids = pending.Select(x => x.Card.Printing.CardMarketId).Distinct().ToList();
-		var resolved = await _resolver.ResolveAsync(ids);
+		var resolved = await _resolver.ResolveAsync(ids, ct);
 
 		var unresolved = new List<PhysicalMtgCard>();
 		foreach (var entry in pending)

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -9,15 +9,15 @@ public class MtgCardCsvHandler
 {
 	readonly CardMapFactory _factory;
 	readonly IReferenceCardCatalog _catalog;
-	readonly IMtgApi _api;
+	readonly ICardmarketResolver _resolver;
 	readonly string _format;
 
-	public MtgCardCsvHandler(IReferenceCardCatalog catalog, IMtgApi api, IConfiguration config, string format)
+	public MtgCardCsvHandler(IReferenceCardCatalog catalog, ICardmarketResolver resolver, IConfiguration config, string format)
 	{
 		_format = format;
 		_factory = new CardMapFactory(config, catalog);
 		_catalog = catalog;
-		_api = api;
+		_resolver = resolver;
 	}
 
 	// Sync wrappers — fine for non-Blazor callers and for formats that don't need network I/O.
@@ -160,7 +160,7 @@ public class MtgCardCsvHandler
 		if (pending.Count == 0) return;
 
 		var ids = pending.Select(x => x.Card.Printing.CardMarketId).Distinct().ToList();
-		var resolved = await _api.GetCardsByCardmarketIdsAsync(ids);
+		var resolved = await _resolver.ResolveAsync(ids);
 
 		var unresolved = new List<PhysicalMtgCard>();
 		foreach (var entry in pending)

--- a/MtgCsvHelper/MtgCsvHelper.csproj
+++ b/MtgCsvHelper/MtgCsvHelper.csproj
@@ -37,4 +37,9 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="MtgCsvHelper.RefreshReferenceData" />
+    <InternalsVisibleTo Include="MtgCsvHelper.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/MtgCsvHelper/ReferenceCard.cs
+++ b/MtgCsvHelper/ReferenceCard.cs
@@ -28,4 +28,30 @@ public sealed record ReferenceCard(
 	int? CardmarketId,
 	int? TcgplayerId,
 	int? TcgplayerEtchedId,
-	IReadOnlyList<int>? MultiverseIds);
+	IReadOnlyList<int>? MultiverseIds)
+{
+	/// <summary>
+	/// Builds a <see cref="ReferenceCard"/> from the canonical <see cref="ScryfallCardJson"/> wire
+	/// shape, applying the defaults in one place: <c>Lang</c> falls back to <c>"en"</c>, <c>Layout</c>
+	/// to <c>"normal"</c>, <c>Finishes</c> to an empty list. Both the bundle generator and the runtime
+	/// network fallback go through this factory, so the field list and defaulting rules can't
+	/// silently drift between them.
+	/// </summary>
+	public static ReferenceCard CreateFromScryfall(ScryfallCardJson c) => new(
+		Id: c.Id,
+		OracleId: c.OracleId,
+		Name: c.Name,
+		Set: c.Set,
+		SetName: c.SetName,
+		CollectorNumber: c.CollectorNumber,
+		Lang: string.IsNullOrEmpty(c.Lang) ? "en" : c.Lang,
+		Layout: string.IsNullOrEmpty(c.Layout) ? "normal" : c.Layout,
+		Finishes: c.Finishes ?? [],
+		FrameEffects: c.FrameEffects,
+		BorderColor: c.BorderColor,
+		PromoTypes: c.PromoTypes,
+		CardmarketId: c.CardmarketId,
+		TcgplayerId: c.TcgplayerId,
+		TcgplayerEtchedId: c.TcgplayerEtchedId,
+		MultiverseIds: c.MultiverseIds);
+}

--- a/MtgCsvHelper/ReferenceCard.cs
+++ b/MtgCsvHelper/ReferenceCard.cs
@@ -30,14 +30,7 @@ public sealed record ReferenceCard(
 	int? TcgplayerEtchedId,
 	IReadOnlyList<int>? MultiverseIds)
 {
-	/// <summary>
-	/// Builds a <see cref="ReferenceCard"/> from the canonical <see cref="ScryfallCardJson"/> wire
-	/// shape, applying the defaults in one place: <c>Lang</c> falls back to <c>"en"</c>, <c>Layout</c>
-	/// to <c>"normal"</c>, <c>Finishes</c> to an empty list. Both the bundle generator and the runtime
-	/// network fallback go through this factory, so the field list and defaulting rules can't
-	/// silently drift between them. Internal because the input <see cref="ScryfallCardJson"/> is
-	/// internal — external consumers should use the positional constructor directly.
-	/// </summary>
+	/// <summary> Single canonical factory used by the bundle generator and the runtime network path — keeps Lang/Layout/Finishes defaults from drifting between them. </summary>
 	internal static ReferenceCard CreateFromScryfall(ScryfallCardJson c) => new(
 		Id: c.Id,
 		OracleId: c.OracleId,

--- a/MtgCsvHelper/ReferenceCard.cs
+++ b/MtgCsvHelper/ReferenceCard.cs
@@ -35,9 +35,10 @@ public sealed record ReferenceCard(
 	/// shape, applying the defaults in one place: <c>Lang</c> falls back to <c>"en"</c>, <c>Layout</c>
 	/// to <c>"normal"</c>, <c>Finishes</c> to an empty list. Both the bundle generator and the runtime
 	/// network fallback go through this factory, so the field list and defaulting rules can't
-	/// silently drift between them.
+	/// silently drift between them. Internal because the input <see cref="ScryfallCardJson"/> is
+	/// internal — external consumers should use the positional constructor directly.
 	/// </summary>
-	public static ReferenceCard CreateFromScryfall(ScryfallCardJson c) => new(
+	internal static ReferenceCard CreateFromScryfall(ScryfallCardJson c) => new(
 		Id: c.Id,
 		OracleId: c.OracleId,
 		Name: c.Name,

--- a/MtgCsvHelper/ScryfallCardJson.cs
+++ b/MtgCsvHelper/ScryfallCardJson.cs
@@ -7,10 +7,10 @@ namespace MtgCsvHelper;
 /// in <see cref="ReferenceCard"/>. Used as the deserialization target for both the bulk-data
 /// pipeline (bundle generator) and the per-card endpoint (<c>CachedMtgApi</c>), so the field
 /// list lives in exactly one place. Nullable where Scryfall may omit the property (<c>oracle_id</c>
-/// on tokens/emblems, the various external-id fields). Not a stable public API — its shape
-/// follows whatever Scryfall ships; consumers should work with <see cref="ReferenceCard"/> instead.
+/// on tokens/emblems, the various external-id fields). Internal because its shape follows
+/// whatever Scryfall ships — consumers should work with <see cref="ReferenceCard"/> instead.
 /// </summary>
-public sealed record ScryfallCardJson(
+internal sealed record ScryfallCardJson(
 	Guid Id,
 	[property: JsonPropertyName("oracle_id")] Guid? OracleId,
 	string Name,

--- a/MtgCsvHelper/ScryfallCardJson.cs
+++ b/MtgCsvHelper/ScryfallCardJson.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace MtgCsvHelper;
+
+/// <summary>
+/// Minimal mirror of the Scryfall JSON shape for a single printing — only the fields we keep
+/// in <see cref="ReferenceCard"/>. Used as the deserialization target for both the bulk-data
+/// pipeline (bundle generator) and the per-card endpoint (<c>CachedMtgApi</c>), so the field
+/// list lives in exactly one place. Nullable where Scryfall may omit the property (<c>oracle_id</c>
+/// on tokens/emblems, the various external-id fields). Not a stable public API — its shape
+/// follows whatever Scryfall ships; consumers should work with <see cref="ReferenceCard"/> instead.
+/// </summary>
+public sealed record ScryfallCardJson(
+	Guid Id,
+	[property: JsonPropertyName("oracle_id")] Guid? OracleId,
+	string Name,
+	string Set,
+	[property: JsonPropertyName("set_name")] string SetName,
+	[property: JsonPropertyName("collector_number")] string CollectorNumber,
+	string? Lang,
+	string? Layout,
+	List<string>? Finishes,
+	[property: JsonPropertyName("frame_effects")] List<string>? FrameEffects,
+	[property: JsonPropertyName("border_color")] string? BorderColor,
+	[property: JsonPropertyName("promo_types")] List<string>? PromoTypes,
+	[property: JsonPropertyName("cardmarket_id")] int? CardmarketId,
+	[property: JsonPropertyName("tcgplayer_id")] int? TcgplayerId,
+	[property: JsonPropertyName("tcgplayer_etched_id")] int? TcgplayerEtchedId,
+	[property: JsonPropertyName("multiverse_ids")] List<int>? MultiverseIds);

--- a/MtgCsvHelper/ServiceConfiguration.cs
+++ b/MtgCsvHelper/ServiceConfiguration.cs
@@ -6,7 +6,8 @@ namespace MtgCsvHelper;
 public static class ServiceConfiguration
 {
 	/// <summary>
-	/// Registers the always-available <see cref="IMtgApi"/> singleton.
+	/// Registers the always-available <see cref="IMtgApi"/> and <see cref="ICardmarketResolver"/>
+	/// singletons.
 	/// </summary>
 	/// <remarks>
 	/// Caller must <b>also</b> register <see cref="IReferenceCardCatalog"/> before resolving
@@ -17,6 +18,8 @@ public static class ServiceConfiguration
 	public static IServiceCollection ConfigureMtgCsvHelper(this IServiceCollection services)
 	{
 		services.AddSingleton<IMtgApi, CachedMtgApi>();
+		services.AddSingleton<ICardmarketResolver, CardmarketResolver>();
+
 		return services;
 	}
 }

--- a/MtgCsvHelper/Services/CachedMtgApi.cs
+++ b/MtgCsvHelper/Services/CachedMtgApi.cs
@@ -12,6 +12,7 @@ namespace MtgCsvHelper.Services;
 /// </summary>
 public class CachedMtgApi : IMtgApi
 {
+	// Single-threaded use only (sequential calls per parse); swap to ConcurrentDictionary if that ever changes.
 	readonly Dictionary<int, ReferenceCard> _cardsByCardmarketId = [];
 
 	public CachedMtgApi() => Log.Debug("CachedMtgApi created");

--- a/MtgCsvHelper/Services/CachedMtgApi.cs
+++ b/MtgCsvHelper/Services/CachedMtgApi.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using ScryfallApi.Client;
 
@@ -12,8 +13,8 @@ namespace MtgCsvHelper.Services;
 /// </summary>
 public class CachedMtgApi : IMtgApi
 {
-	// Single-threaded use only (sequential calls per parse); swap to ConcurrentDictionary if that ever changes.
-	readonly Dictionary<int, ReferenceCard> _cardsByCardmarketId = [];
+	// ConcurrentDictionary because CachedMtgApi is registered as a DI singleton — protects against future ASP.NET-style concurrent callers.
+	readonly ConcurrentDictionary<int, ReferenceCard> _cardsByCardmarketId = new();
 
 	public CachedMtgApi() => Log.Debug("CachedMtgApi created");
 

--- a/MtgCsvHelper/Services/CachedMtgApi.cs
+++ b/MtgCsvHelper/Services/CachedMtgApi.cs
@@ -7,10 +7,12 @@ namespace MtgCsvHelper.Services;
 /// <summary>
 /// Network fallback for Scryfall lookups not covered by <see cref="IReferenceCardCatalog"/>:
 /// per-card resolution by cardmarket_id, cached in-process for the lifetime of the instance.
+/// Scryfall's response shape is mapped to <see cref="ReferenceCard"/> on the way out so callers
+/// see only canonical types.
 /// </summary>
 public class CachedMtgApi : IMtgApi
 {
-	readonly Dictionary<int, Card> _cardsByCardmarketId = [];
+	readonly Dictionary<int, ReferenceCard> _cardsByCardmarketId = [];
 
 	public CachedMtgApi() => Log.Debug("CachedMtgApi created");
 
@@ -35,7 +37,7 @@ public class CachedMtgApi : IMtgApi
 		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
 	};
 
-	public async Task<IReadOnlyDictionary<int, Card>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds)
+	public async Task<IReadOnlyDictionary<int, ReferenceCard>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds)
 	{
 		var requested = cardmarketIds.Distinct().ToList();
 		var notYetFetched = requested.Where(id => !_cardsByCardmarketId.ContainsKey(id)).ToList();
@@ -55,7 +57,7 @@ public class CachedMtgApi : IMtgApi
 				var card = JsonSerializer.Deserialize<Card>(body, ScryfallJsonOptions);
 				if (card is not null)
 				{
-					_cardsByCardmarketId[id] = card;
+					_cardsByCardmarketId[id] = MapToReferenceCard(card);
 				}
 			}
 			catch (HttpRequestException ex)
@@ -73,4 +75,26 @@ public class CachedMtgApi : IMtgApi
 			.Where(_cardsByCardmarketId.ContainsKey)
 			.ToDictionary(id => id, id => _cardsByCardmarketId[id]);
 	}
+
+	// Mirror of the same field choices made by the bundle generator (tools/MtgCsvHelper.RefreshReferenceData):
+	// strip a Scryfall printing to the fields ReferenceCard exposes, with the same defaults (Lang/Layout/Finishes).
+	// Card.CardMarketId / TcgplayerId / TcgplayerEtchedId are non-nullable ints in the Scryfall library and use 0
+	// as the "unset" sentinel; we collapse 0 -> null on the way out so consumers can distinguish "no id" from "id 0".
+	static ReferenceCard MapToReferenceCard(Card c) => new(
+		Id: c.Id,
+		OracleId: Guid.TryParse(c.OracleId, out var oid) ? oid : null,
+		Name: c.Name,
+		Set: c.Set,
+		SetName: c.SetName,
+		CollectorNumber: c.CollectorNumber,
+		Lang: string.IsNullOrEmpty(c.Language) ? "en" : c.Language,
+		Layout: string.IsNullOrEmpty(c.Layout) ? "normal" : c.Layout,
+		Finishes: c.Finishes ?? [],
+		FrameEffects: c.FrameEffects,
+		BorderColor: c.BorderColor,
+		PromoTypes: c.PromoTypes,
+		CardmarketId: c.CardMarketId > 0 ? c.CardMarketId : null,
+		TcgplayerId: c.TcgplayerId > 0 ? c.TcgplayerId : null,
+		TcgplayerEtchedId: c.TcgplayerEtchedId > 0 ? c.TcgplayerEtchedId : null,
+		MultiverseIds: c.MultiverseIds);
 }

--- a/MtgCsvHelper/Services/CachedMtgApi.cs
+++ b/MtgCsvHelper/Services/CachedMtgApi.cs
@@ -13,7 +13,7 @@ namespace MtgCsvHelper.Services;
 /// </summary>
 public class CachedMtgApi : IMtgApi
 {
-	// ConcurrentDictionary because CachedMtgApi is registered as a DI singleton — protects against future ASP.NET-style concurrent callers.
+	// ConcurrentDictionary because CachedMtgApi is a DI singleton — keeps the cache consistent under concurrent callers (duplicate fetches of the same id are still possible but idempotent).
 	readonly ConcurrentDictionary<int, ReferenceCard> _cardsByCardmarketId = new();
 
 	public CachedMtgApi() => Log.Debug("CachedMtgApi created");

--- a/MtgCsvHelper/Services/CachedMtgApi.cs
+++ b/MtgCsvHelper/Services/CachedMtgApi.cs
@@ -1,14 +1,14 @@
 using System.Text.Json;
 using ScryfallApi.Client;
-using ScryfallApi.Client.Models;
 
 namespace MtgCsvHelper.Services;
 
 /// <summary>
 /// Network fallback for Scryfall lookups not covered by <see cref="IReferenceCardCatalog"/>:
 /// per-card resolution by cardmarket_id, cached in-process for the lifetime of the instance.
-/// Scryfall's response shape is mapped to <see cref="ReferenceCard"/> on the way out so callers
-/// see only canonical types.
+/// Scryfall's response is deserialized into the shared <see cref="ScryfallCardJson"/> DTO and
+/// then run through <see cref="ReferenceCard.CreateFromScryfall"/>, the same factory the bundle
+/// generator uses — keeping the wire-format mapping in a single, canonical place.
 /// </summary>
 public class CachedMtgApi : IMtgApi
 {
@@ -54,10 +54,10 @@ public class CachedMtgApi : IMtgApi
 				}
 				response.EnsureSuccessStatusCode();
 				var body = await response.Content.ReadAsStringAsync();
-				var card = JsonSerializer.Deserialize<Card>(body, ScryfallJsonOptions);
+				var card = JsonSerializer.Deserialize<ScryfallCardJson>(body, ScryfallJsonOptions);
 				if (card is not null)
 				{
-					_cardsByCardmarketId[id] = MapToReferenceCard(card);
+					_cardsByCardmarketId[id] = ReferenceCard.CreateFromScryfall(card);
 				}
 			}
 			catch (HttpRequestException ex)
@@ -75,26 +75,4 @@ public class CachedMtgApi : IMtgApi
 			.Where(_cardsByCardmarketId.ContainsKey)
 			.ToDictionary(id => id, id => _cardsByCardmarketId[id]);
 	}
-
-	// Mirror of the same field choices made by the bundle generator (tools/MtgCsvHelper.RefreshReferenceData):
-	// strip a Scryfall printing to the fields ReferenceCard exposes, with the same defaults (Lang/Layout/Finishes).
-	// Card.CardMarketId / TcgplayerId / TcgplayerEtchedId are non-nullable ints in the Scryfall library and use 0
-	// as the "unset" sentinel; we collapse 0 -> null on the way out so consumers can distinguish "no id" from "id 0".
-	static ReferenceCard MapToReferenceCard(Card c) => new(
-		Id: c.Id,
-		OracleId: Guid.TryParse(c.OracleId, out var oid) ? oid : null,
-		Name: c.Name,
-		Set: c.Set,
-		SetName: c.SetName,
-		CollectorNumber: c.CollectorNumber,
-		Lang: string.IsNullOrEmpty(c.Language) ? "en" : c.Language,
-		Layout: string.IsNullOrEmpty(c.Layout) ? "normal" : c.Layout,
-		Finishes: c.Finishes ?? [],
-		FrameEffects: c.FrameEffects,
-		BorderColor: c.BorderColor,
-		PromoTypes: c.PromoTypes,
-		CardmarketId: c.CardMarketId > 0 ? c.CardMarketId : null,
-		TcgplayerId: c.TcgplayerId > 0 ? c.TcgplayerId : null,
-		TcgplayerEtchedId: c.TcgplayerEtchedId > 0 ? c.TcgplayerEtchedId : null,
-		MultiverseIds: c.MultiverseIds);
 }

--- a/MtgCsvHelper/Services/CachedMtgApi.cs
+++ b/MtgCsvHelper/Services/CachedMtgApi.cs
@@ -37,7 +37,7 @@ public class CachedMtgApi : IMtgApi
 		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
 	};
 
-	public async Task<IReadOnlyDictionary<int, ReferenceCard>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds)
+	public async Task<IReadOnlyDictionary<int, ReferenceCard>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds, CancellationToken ct = default)
 	{
 		var requested = cardmarketIds.Distinct().ToList();
 		var notYetFetched = requested.Where(id => !_cardsByCardmarketId.ContainsKey(id)).ToList();
@@ -47,13 +47,13 @@ public class CachedMtgApi : IMtgApi
 			var id = notYetFetched[i];
 			try
 			{
-				var response = await ScryfallHttpClient.GetAsync(new Uri($"https://api.scryfall.com/cards/cardmarket/{id}"));
+				var response = await ScryfallHttpClient.GetAsync(new Uri($"https://api.scryfall.com/cards/cardmarket/{id}"), ct);
 				if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
 				{
 					continue; // not found — caller will see this id absent from the returned dictionary
 				}
 				response.EnsureSuccessStatusCode();
-				var body = await response.Content.ReadAsStringAsync();
+				var body = await response.Content.ReadAsStringAsync(ct);
 				var card = JsonSerializer.Deserialize<ScryfallCardJson>(body, ScryfallJsonOptions);
 				if (card is not null)
 				{
@@ -67,7 +67,7 @@ public class CachedMtgApi : IMtgApi
 
 			if (i + 1 < notYetFetched.Count)
 			{
-				await Task.Delay(InterRequestDelayMs);
+				await Task.Delay(InterRequestDelayMs, ct);
 			}
 		}
 

--- a/MtgCsvHelper/Services/CardmarketResolver.cs
+++ b/MtgCsvHelper/Services/CardmarketResolver.cs
@@ -1,0 +1,33 @@
+namespace MtgCsvHelper.Services;
+
+/// <summary>
+/// Default <see cref="ICardmarketResolver"/>: catalog first, batched Scryfall fallback for misses.
+/// No additional cache layer — <see cref="IMtgApi"/> already caches its network results in-process,
+/// and catalog lookups are O(1) dictionary reads, so stacking another dictionary buys nothing.
+/// </summary>
+public sealed class CardmarketResolver(IReferenceCardCatalog catalog, IMtgApi api) : ICardmarketResolver
+{
+	public async Task<IReadOnlyDictionary<int, ReferenceCard>> ResolveAsync(IEnumerable<int> cardmarketIds)
+	{
+		var resolved = new Dictionary<int, ReferenceCard>();
+		var misses = new List<int>();
+
+		foreach (var id in cardmarketIds.Distinct())
+		{
+			var hit = catalog.FindByCardmarketId(id);
+			if (hit is not null) { resolved[id] = hit; }
+			else { misses.Add(id); }
+		}
+
+		if (misses.Count > 0)
+		{
+			var fetched = await api.GetCardsByCardmarketIdsAsync(misses);
+			foreach (var (id, card) in fetched)
+			{
+				resolved[id] = card;
+			}
+		}
+
+		return resolved;
+	}
+}

--- a/MtgCsvHelper/Services/CardmarketResolver.cs
+++ b/MtgCsvHelper/Services/CardmarketResolver.cs
@@ -12,7 +12,8 @@ public sealed class CardmarketResolver(IReferenceCardCatalog catalog, IMtgApi ap
 		var resolved = new Dictionary<int, ReferenceCard>();
 		var misses = new List<int>();
 
-		foreach (var id in cardmarketIds.Distinct())
+		// No Distinct here: handler dedupes before calling; CachedMtgApi dedupes again at the network boundary.
+		foreach (var id in cardmarketIds)
 		{
 			var hit = catalog.FindByCardmarketId(id);
 			if (hit is not null) { resolved[id] = hit; }

--- a/MtgCsvHelper/Services/CardmarketResolver.cs
+++ b/MtgCsvHelper/Services/CardmarketResolver.cs
@@ -7,7 +7,7 @@ namespace MtgCsvHelper.Services;
 /// </summary>
 public sealed class CardmarketResolver(IReferenceCardCatalog catalog, IMtgApi api) : ICardmarketResolver
 {
-	public async Task<IReadOnlyDictionary<int, ReferenceCard>> ResolveAsync(IEnumerable<int> cardmarketIds)
+	public async Task<IReadOnlyDictionary<int, ReferenceCard>> ResolveAsync(IEnumerable<int> cardmarketIds, CancellationToken ct = default)
 	{
 		var resolved = new Dictionary<int, ReferenceCard>();
 		var misses = new List<int>();
@@ -21,7 +21,7 @@ public sealed class CardmarketResolver(IReferenceCardCatalog catalog, IMtgApi ap
 
 		if (misses.Count > 0)
 		{
-			var fetched = await api.GetCardsByCardmarketIdsAsync(misses);
+			var fetched = await api.GetCardsByCardmarketIdsAsync(misses, ct);
 			foreach (var (id, card) in fetched)
 			{
 				resolved[id] = card;

--- a/MtgCsvHelper/Services/ICardmarketResolver.cs
+++ b/MtgCsvHelper/Services/ICardmarketResolver.cs
@@ -8,10 +8,10 @@ namespace MtgCsvHelper.Services;
 public interface ICardmarketResolver
 {
 	/// <summary>
-	/// Resolve a batch of cardmarket_ids. IDs absent from both the catalog and Scryfall are
-	/// absent from the returned dictionary (caller decides how to surface the miss). The token
-	/// flows through to <see cref="IMtgApi.GetCardsByCardmarketIdsAsync"/> and from there to the
-	/// underlying <c>HttpClient</c>; cancelling aborts the in-flight Scryfall request.
+	/// Resolve a batch of cardmarket_ids. Duplicate IDs are tolerated; each is resolved at most
+	/// once. IDs absent from both the catalog and Scryfall are absent from the returned dictionary
+	/// (caller decides how to surface the miss). Cancelling the token aborts the in-flight Scryfall
+	/// request.
 	/// </summary>
 	Task<IReadOnlyDictionary<int, ReferenceCard>> ResolveAsync(IEnumerable<int> cardmarketIds, CancellationToken ct = default);
 }

--- a/MtgCsvHelper/Services/ICardmarketResolver.cs
+++ b/MtgCsvHelper/Services/ICardmarketResolver.cs
@@ -1,0 +1,15 @@
+namespace MtgCsvHelper.Services;
+
+/// <summary>
+/// Resolves Cardmarket product IDs to <see cref="ReferenceCard"/> printings. Catalog-first:
+/// the bundled <see cref="IReferenceCardCatalog"/> is consulted in-process before any network
+/// call. Misses fall back to <see cref="IMtgApi"/> in a single batched request.
+/// </summary>
+public interface ICardmarketResolver
+{
+	/// <summary>
+	/// Resolve a batch of cardmarket_ids. IDs absent from both the catalog and Scryfall are
+	/// absent from the returned dictionary (caller decides how to surface the miss).
+	/// </summary>
+	Task<IReadOnlyDictionary<int, ReferenceCard>> ResolveAsync(IEnumerable<int> cardmarketIds);
+}

--- a/MtgCsvHelper/Services/ICardmarketResolver.cs
+++ b/MtgCsvHelper/Services/ICardmarketResolver.cs
@@ -9,7 +9,9 @@ public interface ICardmarketResolver
 {
 	/// <summary>
 	/// Resolve a batch of cardmarket_ids. IDs absent from both the catalog and Scryfall are
-	/// absent from the returned dictionary (caller decides how to surface the miss).
+	/// absent from the returned dictionary (caller decides how to surface the miss). The token
+	/// flows through to <see cref="IMtgApi.GetCardsByCardmarketIdsAsync"/> and from there to the
+	/// underlying <c>HttpClient</c>; cancelling aborts the in-flight Scryfall request.
 	/// </summary>
-	Task<IReadOnlyDictionary<int, ReferenceCard>> ResolveAsync(IEnumerable<int> cardmarketIds);
+	Task<IReadOnlyDictionary<int, ReferenceCard>> ResolveAsync(IEnumerable<int> cardmarketIds, CancellationToken ct = default);
 }

--- a/MtgCsvHelper/Services/IMtgApi.cs
+++ b/MtgCsvHelper/Services/IMtgApi.cs
@@ -10,5 +10,6 @@ public interface IMtgApi
 {
 	// Batched lookup of cards by cardmarket_id. Missing IDs are absent from the returned dictionary.
 	// Cached: subsequent calls for already-resolved IDs return instantly without hitting the network.
-	Task<IReadOnlyDictionary<int, ReferenceCard>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds);
+	// The token aborts the in-flight Scryfall request and any inter-request delay.
+	Task<IReadOnlyDictionary<int, ReferenceCard>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds, CancellationToken ct = default);
 }

--- a/MtgCsvHelper/Services/IMtgApi.cs
+++ b/MtgCsvHelper/Services/IMtgApi.cs
@@ -1,17 +1,14 @@
-using ScryfallApi.Client.Models;
-
 namespace MtgCsvHelper.Services;
 
-// TODO: retire once the catalog handles cardmarket_id fallbacks (issue #48).
 /// <summary>
-/// Network access to Scryfall for data NOT covered by the locally-bundled
-/// <see cref="IReferenceCardCatalog"/>. Today: lookups by cardmarket_id for
-/// printings the user has imported but that aren't in the bundle (e.g. cards
-/// added since the bundle was generated).
+/// Network access to Scryfall for printings NOT covered by the locally-bundled
+/// <see cref="IReferenceCardCatalog"/>. Today: lookups by cardmarket_id for cards
+/// added since the bundle was generated. Returns the canonical <see cref="ReferenceCard"/>
+/// shape so callers never see the underlying Scryfall library types.
 /// </summary>
 public interface IMtgApi
 {
-	// Batched lookup of Scryfall cards by their cardmarket_id. Missing IDs are absent from the returned dictionary.
+	// Batched lookup of cards by cardmarket_id. Missing IDs are absent from the returned dictionary.
 	// Cached: subsequent calls for already-resolved IDs return instantly without hitting the network.
-	Task<IReadOnlyDictionary<int, Card>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds);
+	Task<IReadOnlyDictionary<int, ReferenceCard>> GetCardsByCardmarketIdsAsync(IEnumerable<int> cardmarketIds);
 }

--- a/tools/MtgCsvHelper.RefreshReferenceData/Program.cs
+++ b/tools/MtgCsvHelper.RefreshReferenceData/Program.cs
@@ -43,23 +43,7 @@ await foreach (var card in JsonSerializer.DeserializeAsyncEnumerable<ScryfallCar
 {
 	total++;
 	if (card is null) { continue; }
-	stripped.Add(new ReferenceCard(
-		Id: card.Id,
-		OracleId: card.OracleId,
-		Name: card.Name,
-		Set: card.Set,
-		SetName: card.SetName,
-		CollectorNumber: card.CollectorNumber,
-		Lang: card.Lang ?? "en",
-		Layout: card.Layout ?? "normal",
-		Finishes: card.Finishes ?? [],
-		FrameEffects: card.FrameEffects,
-		BorderColor: card.BorderColor,
-		PromoTypes: card.PromoTypes,
-		CardmarketId: card.CardmarketId,
-		TcgplayerId: card.TcgplayerId,
-		TcgplayerEtchedId: card.TcgplayerEtchedId,
-		MultiverseIds: card.MultiverseIds));
+	stripped.Add(ReferenceCard.CreateFromScryfall(card));
 	kept++;
 	if (total % 10_000 == 0) { Console.Write($"\r  parsed {total:N0} cards…"); }
 }
@@ -80,23 +64,3 @@ Console.WriteLine($"Done. Bundle size: {size / 1024.0:F1} KB ({size / 1e6:F2} MB
 internal sealed record BulkDataManifest(List<BulkDataEntry> Data);
 internal sealed record BulkDataEntry(string Type, string Name, long Size,
 	[property: JsonPropertyName("download_uri")] string DownloadUri);
-
-// Minimal mirror of the Scryfall JSON for default_cards — only the fields we keep.
-// OracleId is nullable: tokens / emblems sometimes lack oracle_id in default_cards.
-internal sealed record ScryfallCardJson(
-	Guid Id,
-	[property: JsonPropertyName("oracle_id")] Guid? OracleId,
-	string Name,
-	string Set,
-	[property: JsonPropertyName("set_name")] string SetName,
-	[property: JsonPropertyName("collector_number")] string CollectorNumber,
-	string? Lang,
-	string? Layout,
-	List<string>? Finishes,
-	[property: JsonPropertyName("frame_effects")] List<string>? FrameEffects,
-	[property: JsonPropertyName("border_color")] string? BorderColor,
-	[property: JsonPropertyName("promo_types")] List<string>? PromoTypes,
-	[property: JsonPropertyName("cardmarket_id")] int? CardmarketId,
-	[property: JsonPropertyName("tcgplayer_id")] int? TcgplayerId,
-	[property: JsonPropertyName("tcgplayer_etched_id")] int? TcgplayerEtchedId,
-	[property: JsonPropertyName("multiverse_ids")] List<int>? MultiverseIds);


### PR DESCRIPTION
## Summary

- Introduce `ICardmarketResolver`: catalog-first batched resolution with `IMtgApi` as network fallback for `cardmarket_id`s the bundle doesn''t know. Imports of cards present in the bundle (the common case) are fully offline; only IDs missing from the bundle hit Scryfall.
- `MtgCardCsvHandler` now depends on `ICardmarketResolver` instead of `IMtgApi`. The handler stops knowing anything about catalog-vs-network — it just asks the resolver.
- `IMtgApi` returns `ReferenceCard` instead of Scryfall''s `Card` type, so the network layer no longer leaks the Scryfall library to its consumers.
- `ScryfallCardJson` — the wire-format DTO — is promoted out of the bundle tool into the main library (internal, exposed via `InternalsVisibleTo` to the bundle tool and tests). Both the bundle generator and `CachedMtgApi` deserialize the same DTO and feed it through `ReferenceCard.CreateFromScryfall(...)`, a single canonical factory that owns the Lang/Layout/Finishes defaults. The two mappings can no longer drift.
- `ICardmarketResolver.ResolveAsync` and `IMtgApi.GetCardsByCardmarketIdsAsync` accept a `CancellationToken ct = default`, threaded through `HttpClient.GetAsync` / `ReadAsStringAsync` / `Task.Delay`. In Blazor WASM, a torn-down component can now abort an in-flight Scryfall request.

## Test plan

- [x] New `CardmarketResolverTests` (3 tests): catalog-hit asserts no network egress; network-fallback asserts the spy receives the exact missing IDs; mixed-batch asserts only misses reach the API.
- [x] New `ReferenceCardTests` (3 tests) pin the factory defaults: null inputs hit the canonical fallbacks; empty-string `lang`/`layout` also fall back; non-defaulted fields pass through.
- [x] `CardmarketTests`'' sample CSV (5 cards) resolves entirely from the catalog — that test is now offline.
- [x] All 107 tests pass.
- [x] Build clean (0 warnings, 0 errors).

Closes the Cardmarket angle of #48. The original umbrella scope (full persistent local cache for all Scryfall data) is out of scope here — the existing GitHub Action that runs `RefreshReferenceData` on push-to-`main` already keeps the deployed bundle fresh, which removes the original motivation.