### PR TITLE
Add MTGO CSV format support (closes #65)

### DIFF
--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -350,7 +350,7 @@
 	static readonly IReadOnlyList<string> _outputFormats = CardMapFactory.WritableFormats;
 
 	string _selectedInputFormat = _inputFormats[0];
-	string _selectedOutputFormat = _outputFormats.First(f => f != _selectedInputFormat);
+	string _selectedOutputFormat = "";  // set in OnInitialized — instance field initializers can't reference other instance fields (CS0236).
 
 	IBrowserFile? _csvFile;
 	ConversionResult? _result;
@@ -364,7 +364,11 @@
 
 	readonly CancellationTokenSource _cts = new();
 
-	protected override void OnInitialized() => CatalogLoader.StateChanged += StateHasChanged;
+	protected override void OnInitialized()
+	{
+		CatalogLoader.StateChanged += StateHasChanged;
+		_selectedOutputFormat = _outputFormats.First(f => f != _selectedInputFormat);
+	}
 
 	async Task RetryCatalogLoad()
 	{

--- a/MtgCsvHelper.Tests/CollectorNumberConverterTests.cs
+++ b/MtgCsvHelper.Tests/CollectorNumberConverterTests.cs
@@ -1,0 +1,23 @@
+using MtgCsvHelper.Converters;
+
+namespace MtgCsvHelper.Tests;
+
+// Pins the contract that the read path strips MTGO's "N/M" suffix to "N" and leaves
+// everything else alone. The converter is applied to every format's collector-number map
+// — a no-op for any string without a `/` — so changes here affect more than just MTGO.
+public class CollectorNumberConverterTests
+{
+	// Null/empty handling is inherited from CsvHelper's StringConverter (uses NullValues config)
+	// and not pinned here; the cases below only cover the slash-stripping the converter adds.
+	[Theory]
+	[InlineData("116/350", "116")]    // MTGO N/M form — strip the total
+	[InlineData("116", "116")]        // already plain — no-op
+	[InlineData("U8", "U8")]          // letter-prefix collector numbers (Deckbox) pass through
+	[InlineData("★1", "★1")]         // star-variant promos — no slash, untouched
+	public void ConvertFromString_StripsSetTotal(string input, string expected)
+	{
+		new CollectorNumberConverter()
+			.ConvertFromString(input, row: null!, memberMapData: null!)
+			.Should().Be(expected);
+	}
+}

--- a/MtgCsvHelper.Tests/FormatDetectorTests.cs
+++ b/MtgCsvHelper.Tests/FormatDetectorTests.cs
@@ -13,6 +13,7 @@ public class FormatDetectorTests(ITestOutputHelper output) : BaseTest(output)
 	[InlineData("Quantity,Simple Name,Set Code,Set,Card Number,Printing,Condition,Language", "TCGPLAYER")]
 	[InlineData("Card,Set ID,Set Name,Quantity,Foil,Collector Number", "MTGGOLDFISH")]
 	[InlineData("Quantity,Name,Finish,Condition,Date Added,Language,Purchase Price,Tags,Edition Name,Edition Code,Multiverse Id,Scryfall ID,Collector Number", "ARCHIDEKT")]
+	[InlineData("Card Name,Quantity,ID #,Rarity,Set,Collector #,Premium,Sideboarded,Annotation", "MTGO")]
 	[InlineData("idProduct;groupCount;isFoil;condition;idLanguage;price", "CARDMARKET")]
 	// CARDKINGDOM uses lowercase headers, distinct from any other format in the configured set.
 	// No matching fixture in Resources/SampleCsvs/Collection (the sample file uses Title-Case
@@ -60,6 +61,7 @@ public class FormatDetectorTests(ITestOutputHelper output) : BaseTest(output)
 	[InlineData("mtggoldfish-from-mtgarena.csv", "MTGGOLDFISH")]
 	[InlineData("tcgplayer-collection.csv", "TCGPLAYER")]
 	[InlineData("tcgplayer-collection-old.csv", "TCGPLAYER")]
+	[InlineData("mtgo-collection.csv", "MTGO")]
 	public void DetectsRealFixtureFiles(string fixtureName, string expectedFormat)
 	{
 		var path = Path.Combine("Resources", "SampleCsvs", "Collection", fixtureName);

--- a/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
+++ b/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
@@ -90,6 +90,11 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 		// "116/350" → "116" stripping verification.
 		result.Collection.Cards.Select(c => c.Printing.CollectorNumber)
 			.Should().AllSatisfy(n => n.Should().NotContain("/"));
+
+		// MTGO 2-letter codes (MI, VI, TE, EX) must be rewritten to canonical 3-letter Scryfall
+		// codes (MIR, VIS, TMP, EXO) so MTGO → other-format conversions emit the right code.
+		result.Collection.Cards.Should().AllSatisfy(c =>
+			c.Printing.Set.Should().HaveLength(3, "MTGO 2-letter codes should be resolved to canonical Scryfall codes"));
 	}
 
 	MtgCardCsvHandler CreateHandler(string deckFormatName) => new(_catalog, _resolver, _config, deckFormatName);

--- a/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
+++ b/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
@@ -74,6 +74,24 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 		cards.Should().HaveCountGreaterThan(500);
 	}
 
+	[Fact]
+	public void Mtgo_AllRowsParse_WithCollectorNumberStrippedAndMtgoCodeAliased()
+	{
+		// MTGO fixture has 7 rows of old-set printings (Mirage, Visions, Tempest, Exodus).
+		// Two MTGO-specific quirks the parser handles: collector numbers in "N/M" form
+		// (116/350 → 116) and 2-letter set codes (MI → MIR via the bundled mtgo_code map).
+		var handler = CreateHandler("MTGO");
+		var result = handler.ParseCollectionCsv($"{COLLECTIONS_FOLDER}/mtgo-collection.csv");
+
+		result.Collection.Cards.Should().HaveCount(7);
+		result.ErrorCount.Should().Be(0,
+			$"all 7 rows are real printings with valid (Set, Collector#) once aliased. Issues: {string.Join("; ", result.Issues.Select(i => i.Reason))}");
+
+		// "116/350" → "116" stripping verification.
+		result.Collection.Cards.Select(c => c.Printing.CollectorNumber)
+			.Should().AllSatisfy(n => n.Should().NotContain("/"));
+	}
+
 	MtgCardCsvHandler CreateHandler(string deckFormatName) => new(_catalog, _resolver, _config, deckFormatName);
 
 	static List<PhysicalMtgCard> GetReferenceCards(Currency currency)

--- a/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
+++ b/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
@@ -97,6 +97,32 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 			c.Printing.Set.Should().HaveLength(3, "MTGO 2-letter codes should be resolved to canonical Scryfall codes"));
 	}
 
+	[Fact]
+	public void Mtgo_ConvertToMoxfield_EmitsCanonicalSetCodesInOutput()
+	{
+		// End-to-end through the WRITE path: parse MTGO, write to Moxfield, then inspect the
+		// emitted CSV. Catches any regression that bypasses the in-memory canonicalization but
+		// still produces a non-canonical code in the output column.
+		var reader = CreateHandler("MTGO");
+		var writer = CreateHandler("MOXFIELD");
+
+		var cards = reader.ParseCollectionCsv($"{COLLECTIONS_FOLDER}/mtgo-collection.csv").Collection.Cards;
+		using var output = new MemoryStream();
+		writer.WriteCollectionCsv(cards, output);
+		var csv = System.Text.Encoding.UTF8.GetString(output.ToArray());
+
+		// Each canonical 3-letter code from the 7 fixture rows must appear in the output.
+		foreach (var canonical in new[] { "MIR", "VIS", "TMP", "EXO" })
+		{
+			csv.Should().Contain(canonical, $"row(s) of {canonical} should round-trip through the write path");
+		}
+		// And no MTGO 2-letter code should leak through.
+		foreach (var mtgo in new[] { ",MI,", ",VI,", ",TE,", ",EX," })
+		{
+			csv.Should().NotContain(mtgo, $"MTGO 2-letter code {mtgo.Trim(',')} must be canonicalized before write");
+		}
+	}
+
 	MtgCardCsvHandler CreateHandler(string deckFormatName) => new(_catalog, _resolver, _config, deckFormatName);
 
 	static List<PhysicalMtgCard> GetReferenceCards(Currency currency)

--- a/MtgCsvHelper.Tests/ReferenceCardCatalogTests.cs
+++ b/MtgCsvHelper.Tests/ReferenceCardCatalogTests.cs
@@ -128,12 +128,13 @@ public class ReferenceCardCatalogTests
 	}
 
 	[Fact]
-	public void FindBySetAndCollectorNumber_IsCaseSensitive_BackingDictionaryUsesOrdinal()
+	public void FindBySetAndCollectorNumber_IsCaseInsensitive_NormalizedAtBoundary()
 	{
-		// Set codes are uppercase by convention in Scryfall data; lookup is case-sensitive.
-		// This test documents the contract — flipping to case-insensitive would be an
-		// intentional change, not an accident.
-		Catalog().FindBySetAndCollectorNumber("m11", "149").Should().BeNull();
+		// Set codes are stored uppercase canonical; the lookup method normalizes input casing
+		// once at the entry point so callers don't need to. "m11" and "M11" both resolve.
+		var lower = Catalog().FindBySetAndCollectorNumber("m11", "149");
+		var upper = Catalog().FindBySetAndCollectorNumber("M11", "149");
+		lower.Should().NotBeNull().And.Be(upper);
 	}
 
 	[Fact]
@@ -145,15 +146,6 @@ public class ReferenceCardCatalogTests
 		sets.Should().Contain(new KeyValuePair<string, string>("ISD", "Innistrad"));
 		sets.Should().Contain(new KeyValuePair<string, string>("TMH2", "Modern Horizons 2 Tokens"));
 		sets.Should().Contain(new KeyValuePair<string, string>("CMM", "Commander Masters"));
-	}
-
-	[Fact]
-	public void IsDoubleFacedName_OnlyTrueForTransformedNames()
-	{
-		var c = Catalog();
-		c.IsDoubleFacedName("Delver of Secrets // Insectile Aberration").Should().BeTrue();
-		c.IsDoubleFacedName("Lightning Bolt").Should().BeFalse();
-		c.IsDoubleFacedName("Unknown Card").Should().BeFalse();
 	}
 
 	[Fact]

--- a/MtgCsvHelper.Tests/TestCollectionFixtureTests.cs
+++ b/MtgCsvHelper.Tests/TestCollectionFixtureTests.cs
@@ -58,9 +58,10 @@ public class TestCollectionFixtureTests(CatalogFixture fixture, ITestOutputHelpe
 	// still enforces "no silent drops" (cards + errors == data rows).
 	static readonly IReadOnlyDictionary<string, (int ExpectedErrors, string TrackingIssue)> KnownDivergence = new Dictionary<string, (int, string)>
 	{
-		// Deckbox emits internal token codes (EX_127, EX_145), legacy aliases (1E, AL, AP), and
-		// renamed list code PLIST → Scryfall plst. Aliasing table tracked by #31.
-		["deckbox-reference-collection.csv"] = (ExpectedErrors: 8, TrackingIssue: "#31"),
+		// Deckbox emits internal token codes (EX_127, EX_145), legacy aliases (PLIST x2, 1E, AP),
+		// and renamed list code PLIST → Scryfall plst. The MTGO alias map now rescues one of the
+		// originally-8 errors (AL → ALL via mtgo_code); remaining aliasing tracked by #31.
+		["deckbox-reference-collection.csv"] = (ExpectedErrors: 7, TrackingIssue: "#31"),
 	};
 
 	[Theory]

--- a/MtgCsvHelper/CardMapFactory.cs
+++ b/MtgCsvHelper/CardMapFactory.cs
@@ -8,7 +8,7 @@ public class CardMapFactory(IConfiguration config, IReferenceCardCatalog catalog
 {
 	readonly List<FormatConfig> _formatConfigs = From(config).ToList();
 
-	public static IReadOnlyList<string> Supported { get; } = ["MOXFIELD", "DRAGONSHIELD", "MANABOX", "TOPDECKED", "DECKBOX", "CARDKINGDOM", "MTGGOLDFISH", "TCGPLAYER", "CARDMARKET", "ARCHIDEKT"];
+	public static IReadOnlyList<string> Supported { get; } = ["MOXFIELD", "DRAGONSHIELD", "MANABOX", "TOPDECKED", "DECKBOX", "CARDKINGDOM", "MTGGOLDFISH", "TCGPLAYER", "CARDMARKET", "ARCHIDEKT", "MTGO"];
 	public static IReadOnlyList<string> NotYetFullySupported { get; } = ["URZAGATHERER"];
 
 	// Formats whose CSV doesn't carry enough info to populate a complete card without external lookups,

--- a/MtgCsvHelper/Converters/CollectorNumberConverter.cs
+++ b/MtgCsvHelper/Converters/CollectorNumberConverter.cs
@@ -9,9 +9,6 @@ namespace MtgCsvHelper.Converters;
 // (we don't know the set total, so MTGO round-trips will emit just "N").
 public class CollectorNumberConverter : StringConverter
 {
-	public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
-	{
-		var stripped = text?.Split('/', 2)[0];
-		return base.ConvertFromString(stripped, row, memberMapData);
-	}
+	public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData) =>
+		text is null ? base.ConvertFromString(text, row, memberMapData) : text.Split('/', 2)[0];
 }

--- a/MtgCsvHelper/Converters/CollectorNumberConverter.cs
+++ b/MtgCsvHelper/Converters/CollectorNumberConverter.cs
@@ -1,0 +1,17 @@
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
+
+namespace MtgCsvHelper.Converters;
+
+// MTGO emits collector numbers as "N/M" (e.g. "116/350") where M is the set total.
+// Strip the suffix on read; all other formats pass through unchanged since "/" doesn't
+// appear in Scryfall collector numbers. Write side preserves whatever's in the model
+// (we don't know the set total, so MTGO round-trips will emit just "N").
+public class CollectorNumberConverter : StringConverter
+{
+	public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
+	{
+		var stripped = text?.Split('/', 2)[0];
+		return base.ConvertFromString(stripped, row, memberMapData);
+	}
+}

--- a/MtgCsvHelper/FormatDisplay.cs
+++ b/MtgCsvHelper/FormatDisplay.cs
@@ -24,6 +24,7 @@ public static class FormatDisplay
 			["CARDMARKET"] = "Cardmarket",
 			["TCGPLAYER"] = "TCGplayer",
 			["ARCHIDEKT"] = "Archidekt",
+			["MTGO"] = "MTGO",
 		};
 
 	public static string For(string format) =>

--- a/MtgCsvHelper/IReferenceCardCatalog.cs
+++ b/MtgCsvHelper/IReferenceCardCatalog.cs
@@ -34,9 +34,6 @@ public interface IReferenceCardCatalog
 	/// </summary>
 	string? GetSetCodeByName(string setName);
 
-	/// <summary> True if at least one printing of this exact name is a double-faced layout. </summary>
-	bool IsDoubleFacedName(string name);
-
 	/// <summary>
 	/// Given a front-face-only name (e.g. "Delver of Secrets"), returns the full double-faced
 	/// name (e.g. "Delver of Secrets // Insectile Aberration"), or null if no double-faced

--- a/MtgCsvHelper/Maps/PhysicalCardMap.cs
+++ b/MtgCsvHelper/Maps/PhysicalCardMap.cs
@@ -30,6 +30,8 @@ public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 		}
 
 		// At least one of SetCode / SetName is expected per format (sites differ on which they include).
+		// CollectorNumberConverter is applied universally (not MTGO-specific) — it's a no-op for any
+		// collector number without a "/", and "/" doesn't appear in Scryfall data.
 		MapOptional(c => c.Printing.CollectorNumber, cfg.SetNumber)?.TypeConverter<CollectorNumberConverter>();
 		MapOptional(c => c.Printing.Set, cfg.SetCode)?.TypeConverter<UpperCaseConverter>();
 		MapOptional(c => c.Printing.SetName, cfg.SetName);

--- a/MtgCsvHelper/Maps/PhysicalCardMap.cs
+++ b/MtgCsvHelper/Maps/PhysicalCardMap.cs
@@ -30,7 +30,7 @@ public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 		}
 
 		// At least one of SetCode / SetName is expected per format (sites differ on which they include).
-		MapOptional(c => c.Printing.CollectorNumber, cfg.SetNumber);
+		MapOptional(c => c.Printing.CollectorNumber, cfg.SetNumber)?.TypeConverter<CollectorNumberConverter>();
 		MapOptional(c => c.Printing.Set, cfg.SetCode)?.TypeConverter<UpperCaseConverter>();
 		MapOptional(c => c.Printing.SetName, cfg.SetName);
 

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -142,14 +142,14 @@ public class MtgCardCsvHandler
 		if (match is null)
 		{
 			issues.Add(new ImportIssue(IssueSeverity.Error, rowNum,
-				$"No printing at {p.Set.ToUpperInvariant()} #{p.CollectorNumber} in Scryfall data", CardName: p.Name));
+				$"No printing at {p.Set} #{p.CollectorNumber} in Scryfall data", CardName: p.Name));
 			return false;
 		}
 
 		if (!NamesMatch(p.Name, match.Name, catalog))
 		{
 			issues.Add(new ImportIssue(IssueSeverity.Error, rowNum,
-				$"Name '{p.Name}' does not match printing at {p.Set.ToUpperInvariant()} #{p.CollectorNumber} ('{match.Name}')",
+				$"Name '{p.Name}' does not match printing at {p.Set} #{p.CollectorNumber} ('{match.Name}')",
 				CardName: p.Name));
 			return false;
 		}
@@ -157,7 +157,7 @@ public class MtgCardCsvHandler
 		if (card.Foil is true && !HasFoilFinish(match.Finishes))
 		{
 			issues.Add(new ImportIssue(IssueSeverity.Error, rowNum,
-				$"Printing {p.Set.ToUpperInvariant()} #{p.CollectorNumber} was not released in foil", CardName: p.Name));
+				$"Printing {p.Set} #{p.CollectorNumber} was not released in foil", CardName: p.Name));
 			return false;
 		}
 

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -138,9 +138,7 @@ public class MtgCardCsvHandler
 		// Missing Set/CollectorNumber already warned by EnrichSetInfo; double-erroring would be noise.
 		if (string.IsNullOrEmpty(p.Set) || string.IsNullOrEmpty(p.CollectorNumber)) { return true; }
 
-		// Scryfall stores set codes lowercase; FindBySetAndCollectorNumber's key is case-sensitive
-		// on the tuple. Imported CSVs use either case (Moxfield uppercase, Topdecked lowercase).
-		var match = catalog.FindBySetAndCollectorNumber(p.Set.ToLowerInvariant(), p.CollectorNumber);
+		var match = catalog.FindBySetAndCollectorNumber(p.Set, p.CollectorNumber);
 		if (match is null)
 		{
 			issues.Add(new ImportIssue(IssueSeverity.Error, rowNum,

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -202,6 +202,9 @@ public class MtgCardCsvHandler
 		// Both directions are O(1) — the catalog maintains forward (code → name) and reverse (name → code) indexes.
 		if (hadSetCode) { p.SetName ??= catalog.GetSetNameByCode(p.Set!); }
 		if (hadSetName) { p.Set ??= catalog.GetSetCodeByName(p.SetName!); }
+		// Rewrite Set to its canonical Scryfall form once SetName is known. Catches MTGO aliases
+		// (MI → MIR) and any lowercase input so downstream writes emit the code other tools expect.
+		if (p.SetName is not null) { p.Set = catalog.GetSetCodeByName(p.SetName) ?? p.Set; }
 
 		if (!hadSetCode && !hadSetName)
 		{

--- a/MtgCsvHelper/ReferenceCard.cs
+++ b/MtgCsvHelper/ReferenceCard.cs
@@ -28,14 +28,20 @@ public sealed record ReferenceCard(
 	int? CardmarketId,
 	int? TcgplayerId,
 	int? TcgplayerEtchedId,
-	IReadOnlyList<int>? MultiverseIds)
+	IReadOnlyList<int>? MultiverseIds,
+	// MTGO uses 2-letter codes for older sets (MI, VI, TE...) that don't match Scryfall's
+	// 3-letter codes (mir, vis, tmp...). Populated from the /sets endpoint at bundle build time;
+	// null for sets MTGO doesn't carry. Catalog uses it as a fallback set-code lookup key.
+	string? MtgoCode = null)
 {
-	/// <summary> Single canonical factory used by the bundle generator and the runtime network path — keeps Lang/Layout/Finishes defaults from drifting between them. </summary>
-	internal static ReferenceCard CreateFromScryfall(ScryfallCardJson c) => new(
+	/// <summary> Single canonical factory used by the bundle generator and the runtime network path.
+	/// Normalizes <see cref="Set"/> and <see cref="MtgoCode"/> to uppercase so downstream code can
+	/// rely on canonical casing without sprinkling <c>ToUpperInvariant</c>/<c>IgnoreCase</c> everywhere. </summary>
+	internal static ReferenceCard CreateFromScryfall(ScryfallCardJson c, string? mtgoCode = null) => new(
 		Id: c.Id,
 		OracleId: c.OracleId,
 		Name: c.Name,
-		Set: c.Set,
+		Set: c.Set.ToUpperInvariant(),
 		SetName: c.SetName,
 		CollectorNumber: c.CollectorNumber,
 		Lang: string.IsNullOrEmpty(c.Lang) ? "en" : c.Lang,
@@ -47,5 +53,6 @@ public sealed record ReferenceCard(
 		CardmarketId: c.CardmarketId,
 		TcgplayerId: c.TcgplayerId,
 		TcgplayerEtchedId: c.TcgplayerEtchedId,
-		MultiverseIds: c.MultiverseIds);
+		MultiverseIds: c.MultiverseIds,
+		MtgoCode: mtgoCode?.ToUpperInvariant());
 }

--- a/MtgCsvHelper/ReferenceCard.cs
+++ b/MtgCsvHelper/ReferenceCard.cs
@@ -34,9 +34,11 @@ public sealed record ReferenceCard(
 	// null for sets MTGO doesn't carry. Catalog uses it as a fallback set-code lookup key.
 	string? MtgoCode = null)
 {
-	// Structural normalization: Set and MtgoCode are always uppercase regardless of how the
-	// record was constructed (factory, JSON deserialization, direct ctor in tests). The catalog's
-	// lookup invariants depend on this — overriding here makes it impossible to bypass.
+	// Normalized at construction: Set and MtgoCode are uppercased for any primary-constructor
+	// invocation (factory, JSON deserialization, direct ctor in tests). The catalog's lookup
+	// invariants depend on uppercase storage. Note: `with { Set = "mir" }` would bypass the
+	// initializer; no such callers exist today, but a future one would need to uppercase
+	// manually or this can be upgraded to a normalizing init setter.
 	public string Set { get; init; } = Set.ToUpperInvariant();
 	public string? MtgoCode { get; init; } = MtgoCode?.ToUpperInvariant();
 

--- a/MtgCsvHelper/ReferenceCard.cs
+++ b/MtgCsvHelper/ReferenceCard.cs
@@ -34,14 +34,18 @@ public sealed record ReferenceCard(
 	// null for sets MTGO doesn't carry. Catalog uses it as a fallback set-code lookup key.
 	string? MtgoCode = null)
 {
-	/// <summary> Single canonical factory used by the bundle generator and the runtime network path.
-	/// Normalizes <see cref="Set"/> and <see cref="MtgoCode"/> to uppercase so downstream code can
-	/// rely on canonical casing without sprinkling <c>ToUpperInvariant</c>/<c>IgnoreCase</c> everywhere. </summary>
+	// Structural normalization: Set and MtgoCode are always uppercase regardless of how the
+	// record was constructed (factory, JSON deserialization, direct ctor in tests). The catalog's
+	// lookup invariants depend on this — overriding here makes it impossible to bypass.
+	public string Set { get; init; } = Set.ToUpperInvariant();
+	public string? MtgoCode { get; init; } = MtgoCode?.ToUpperInvariant();
+
+	/// <summary> Single canonical factory used by the bundle generator and the runtime network path. </summary>
 	internal static ReferenceCard CreateFromScryfall(ScryfallCardJson c, string? mtgoCode = null) => new(
 		Id: c.Id,
 		OracleId: c.OracleId,
 		Name: c.Name,
-		Set: c.Set.ToUpperInvariant(),
+		Set: c.Set,
 		SetName: c.SetName,
 		CollectorNumber: c.CollectorNumber,
 		Lang: string.IsNullOrEmpty(c.Lang) ? "en" : c.Lang,
@@ -54,5 +58,5 @@ public sealed record ReferenceCard(
 		TcgplayerId: c.TcgplayerId,
 		TcgplayerEtchedId: c.TcgplayerEtchedId,
 		MultiverseIds: c.MultiverseIds,
-		MtgoCode: mtgoCode?.ToUpperInvariant());
+		MtgoCode: mtgoCode);
 }

--- a/MtgCsvHelper/ReferenceCardCatalog.cs
+++ b/MtgCsvHelper/ReferenceCardCatalog.cs
@@ -27,8 +27,8 @@ public sealed class ReferenceCardCatalog : IReferenceCardCatalog
 	readonly Dictionary<int, ReferenceCard> _byCardmarketId;
 	readonly Dictionary<(string Set, string CollectorNumber), ReferenceCard> _bySetAndCollector;
 	readonly Dictionary<string, string> _sets;
-	readonly Dictionary<string, string> _setCodeByName;     // "Innistrad" -> "ISD" (uppercase)
-	readonly HashSet<string> _doubleFacedNames;
+	readonly Dictionary<string, string> _setCodeByName;     // "Innistrad" -> "ISD"
+	readonly Dictionary<string, string> _setCodeByMtgoCode; // "MI" -> "MIR"
 	readonly Dictionary<string, string> _frontFaceToFull;  // "Delver of Secrets" -> "Delver of Secrets // Insectile Aberration"
 	readonly HashSet<string> _tokenNames;
 
@@ -41,12 +41,14 @@ public sealed class ReferenceCardCatalog : IReferenceCardCatalog
 		_byId = new(cards.Count);
 		_byCardmarketId = [];
 		_bySetAndCollector = new(cards.Count);
-		_sets = new(StringComparer.OrdinalIgnoreCase);
-		_setCodeByName = new(StringComparer.OrdinalIgnoreCase);
-		_doubleFacedNames = new(StringComparer.OrdinalIgnoreCase);
+		_sets = [];
+		_setCodeByName = new(StringComparer.OrdinalIgnoreCase);  // human-typed names: stay forgiving
+		_setCodeByMtgoCode = [];
 		_frontFaceToFull = new(StringComparer.OrdinalIgnoreCase);
 		_tokenNames = new(StringComparer.OrdinalIgnoreCase);
 
+		// Set codes are uppercase by construction (normalized in ReferenceCard.CreateFromScryfall),
+		// so the set-code dicts can use default comparers — no extra ToUpper/IgnoreCase needed.
 		foreach (var c in cards)
 		{
 			_byId[c.Id] = c;
@@ -54,27 +56,20 @@ public sealed class ReferenceCardCatalog : IReferenceCardCatalog
 			// First-write-wins on duplicate (set, collector_number); Scryfall keeps these unique
 			// per English printing in default_cards but TryAdd makes the intent explicit.
 			_bySetAndCollector.TryAdd((c.Set, c.CollectorNumber), c);
-			// Both set indexes use uppercase keys so GetSets()/GetSetNameByCode/GetSetCodeByName
-			// are consistent — Scryfall's raw set codes are lowercase (e.g. "isd"), but our
-			// public contract is to expose them uppercase to match historical convention.
-			var setUpper = c.Set.ToUpperInvariant();
-			_sets.TryAdd(setUpper, c.SetName);
-			_setCodeByName.TryAdd(c.SetName, setUpper);
+			_sets.TryAdd(c.Set, c.SetName);
+			_setCodeByName.TryAdd(c.SetName, c.Set);
+			if (!string.IsNullOrEmpty(c.MtgoCode)) { _setCodeByMtgoCode.TryAdd(c.MtgoCode, c.Set); }
 
 			bool isToken = TokenLayouts.Contains(c.Layout);
 			if (isToken) { _tokenNames.Add(c.Name); }
 
-			// DFC indexing intentionally skips token/emblem layouts. Tokens like "Bolt // Bolt"
-			// would otherwise pollute the front-face map and shadow real transform pairs because
-			// of TryAdd's first-write-wins semantics.
+			// Front-face → full-name indexing intentionally skips token/emblem layouts.
+			// Tokens like "Bolt // Bolt" would otherwise shadow real transform pairs.
 			if (!isToken && c.Name.Contains(DoubleFacedSeparator, StringComparison.Ordinal))
 			{
-				_doubleFacedNames.Add(c.Name);
 				var split = c.Name.Split(DoubleFacedSeparator, 2);
-				// Skip self-pairs ("X // X" — Scryfall's `reversible_card` layout, where both
-				// faces share the same oracle name). They can't disambiguate a front-face lookup.
-				// Case-insensitive match catches hypothetical "Forest // forest" variants too —
-				// defensive cost: zero.
+				// Skip self-pairs ("X // X" — Scryfall's `reversible_card` layout): same oracle on
+				// both faces, so the front face alone can't disambiguate.
 				if (split.Length == 2 && !split[0].Equals(split[1], StringComparison.OrdinalIgnoreCase))
 				{
 					_frontFaceToFull.TryAdd(split[0], c.Name);
@@ -85,13 +80,26 @@ public sealed class ReferenceCardCatalog : IReferenceCardCatalog
 
 	public ReferenceCard? FindById(Guid scryfallId) => _byId.GetValueOrDefault(scryfallId);
 	public ReferenceCard? FindByCardmarketId(int cardmarketId) => _byCardmarketId.GetValueOrDefault(cardmarketId);
-	public ReferenceCard? FindBySetAndCollectorNumber(string setCode, string collectorNumber) =>
-		_bySetAndCollector.GetValueOrDefault((setCode, collectorNumber));
+	// Callers pass set codes as-typed (Moxfield uppercase, Topdecked lowercase, MTGO 2-letter…).
+	// Storage is canonical uppercase, so input is normalized once at the entry point.
+	public ReferenceCard? FindBySetAndCollectorNumber(string setCode, string collectorNumber)
+	{
+		var canonical = Canonicalize(setCode);
+		return _bySetAndCollector.GetValueOrDefault((canonical, collectorNumber));
+	}
 
 	public IReadOnlyDictionary<string, string> GetSets() => _sets;
-	public string? GetSetNameByCode(string setCode) => _sets.GetValueOrDefault(setCode);
+	public string? GetSetNameByCode(string setCode) => _sets.GetValueOrDefault(Canonicalize(setCode));
+
+	// Returns the canonical Scryfall set code for an input that may be: an MTGO 2-letter code
+	// (MI → MIR), a different-cased canonical code (mir → MIR), or already canonical (MIR → MIR).
+	// Unknown codes pass through as-uppercased (lookups against them will simply miss).
+	string Canonicalize(string setCode)
+	{
+		var upper = setCode.ToUpperInvariant();
+		return _setCodeByMtgoCode.TryGetValue(upper, out var aliased) ? aliased : upper;
+	}
 	public string? GetSetCodeByName(string setName) => _setCodeByName.GetValueOrDefault(setName);
-	public bool IsDoubleFacedName(string name) => _doubleFacedNames.Contains(name);
 	public string? ExpandFrontFaceToFullName(string frontFaceName) => _frontFaceToFull.GetValueOrDefault(frontFaceName);
 	public bool IsTokenName(string name) => _tokenNames.Contains(name);
 

--- a/MtgCsvHelper/Resources/SampleCsvs/Collection/mtgo-collection.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Collection/mtgo-collection.csv
@@ -1,0 +1,8 @@
+Card Name,Quantity,ID #,Rarity,Set,Collector #,Premium,Sideboarded,Annotation
+"Dark Ritual",1,6893,Common,MI,116/350,No,No,0
+"Dirtwater Wraith",1,6901,Common,MI,117/350,No,No,0
+"Stone Rain",4,7333,Common,MI,194/350,No,No,0
+"Dark Privilege",1,7513,Common,VI,56/167,No,No,0
+"Dormant Volcano",1,7523,Uncommon,VI,161/167,No,No,0
+"Capsize",1,9641,Common,TE,55/350,No,No,0
+"Wood Elves",4,10557,Common,EX,130/143,No,No,0

--- a/MtgCsvHelper/appsettings.json
+++ b/MtgCsvHelper/appsettings.json
@@ -352,6 +352,22 @@
       "DateBought": "Date Added"
     },
     {
+      "Name": "MTGO",
+      "Quantity": "Quantity",
+      "CardName": {
+        "HeaderName": "Card Name",
+        "ShortNames": false
+      },
+      "SetCode": "Set",
+      "SetNumber": "Collector #",
+      "Finish": {
+        "HeaderName": "Premium",
+        "Normal": "No",
+        "Foil": "Yes",
+        "Etched": null
+      }
+    },
+    {
       "Name": "CARDKINGDOM",
       "Quantity": "quantity",
       "CardName": {

--- a/tools/MtgCsvHelper.RefreshReferenceData/Program.cs
+++ b/tools/MtgCsvHelper.RefreshReferenceData/Program.cs
@@ -37,6 +37,10 @@ var serializerOptions = new JsonSerializerOptions
 Console.WriteLine("Fetching /sets to build set_code → mtgo_code map…");
 var setsResponse = await http.GetFromJsonAsync<ScryfallList<ScryfallSetJson>>("https://api.scryfall.com/sets", serializerOptions)
 	?? throw new InvalidOperationException("Empty /sets response.");
+if (setsResponse.HasMore)
+{
+	throw new InvalidOperationException("/sets returned a paginated response — implement pagination before the alias map silently truncates.");
+}
 var mtgoCodeBySet = setsResponse.Data
 	.Where(s => !string.IsNullOrEmpty(s.MtgoCode))
 	.ToDictionary(s => s.Code, s => s.MtgoCode!, StringComparer.OrdinalIgnoreCase);
@@ -81,5 +85,5 @@ internal sealed record BulkDataManifest(List<BulkDataEntry> Data);
 internal sealed record BulkDataEntry(string Type, string Name, long Size,
 	[property: JsonPropertyName("download_uri")] string DownloadUri);
 
-internal sealed record ScryfallList<T>(List<T> Data);
+internal sealed record ScryfallList<T>(List<T> Data, [property: JsonPropertyName("has_more")] bool HasMore);
 internal sealed record ScryfallSetJson(string Code, [property: JsonPropertyName("mtgo_code")] string? MtgoCode);

--- a/tools/MtgCsvHelper.RefreshReferenceData/Program.cs
+++ b/tools/MtgCsvHelper.RefreshReferenceData/Program.cs
@@ -34,6 +34,14 @@ var serializerOptions = new JsonSerializerOptions
 	PropertyNameCaseInsensitive = true,
 };
 
+Console.WriteLine("Fetching /sets to build set_code → mtgo_code map…");
+var setsResponse = await http.GetFromJsonAsync<ScryfallList<ScryfallSetJson>>("https://api.scryfall.com/sets", serializerOptions)
+	?? throw new InvalidOperationException("Empty /sets response.");
+var mtgoCodeBySet = setsResponse.Data
+	.Where(s => !string.IsNullOrEmpty(s.MtgoCode))
+	.ToDictionary(s => s.Code, s => s.MtgoCode!, StringComparer.OrdinalIgnoreCase);
+Console.WriteLine($"  {mtgoCodeBySet.Count} sets carry an mtgo_code (of {setsResponse.Data.Count} total).");
+
 Console.WriteLine("Looking up bulk-data manifest from Scryfall…");
 var manifest = await http.GetFromJsonAsync<BulkDataManifest>("https://api.scryfall.com/bulk-data", serializerOptions)
 	?? throw new InvalidOperationException("Empty bulk-data response.");
@@ -50,7 +58,8 @@ await foreach (var card in JsonSerializer.DeserializeAsyncEnumerable<ScryfallCar
 {
 	total++;
 	if (card is null) { continue; }
-	stripped.Add(ReferenceCard.CreateFromScryfall(card));
+	mtgoCodeBySet.TryGetValue(card.Set, out var mtgoCode);
+	stripped.Add(ReferenceCard.CreateFromScryfall(card, mtgoCode));
 	kept++;
 	if (total % 10_000 == 0) { Console.Write($"\r  parsed {total:N0} cards…"); }
 }
@@ -71,3 +80,6 @@ Console.WriteLine($"Done. Bundle size: {size / 1024.0:F1} KB ({size / 1e6:F2} MB
 internal sealed record BulkDataManifest(List<BulkDataEntry> Data);
 internal sealed record BulkDataEntry(string Type, string Name, long Size,
 	[property: JsonPropertyName("download_uri")] string DownloadUri);
+
+internal sealed record ScryfallList<T>(List<T> Data);
+internal sealed record ScryfallSetJson(string Code, [property: JsonPropertyName("mtgo_code")] string? MtgoCode);


### PR DESCRIPTION
## Summary

Implements [#65](https://github.com/StepKie/MtgCsvHelper/issues/65). New `MTGO` format with three MTGO-specific quirks handled:

1. **Collector number `N/M` form** (e.g. `116/350`). New `CollectorNumberConverter` strips the `/M` suffix; applied unconditionally since `/` doesn't appear in Scryfall collector numbers.
2. **2-letter set codes** for older sets (MI, VI, TE, EX, ST…) that don't match Scryfall's 3-letter codes (mir, vis, tmp). Bundle generator now fetches Scryfall's `/sets` endpoint and joins `mtgo_code` into each `ReferenceCard`. The catalog uses the alias map as a fallback in `FindBySetAndCollectorNumber` and `GetSetNameByCode`. 222 of 1038 Scryfall sets carry an `mtgo_code`; the aliasing also rescues one Deckbox fixture row (`AL` → `ALL`), so `KnownDivergence` drops 8 → 7.
3. **`Premium` column maps to Foil** (Yes/No).

## Incidental cleanups (necessary scaffolding)

### Catalog casing refactor
The combination of `StringComparer.OrdinalIgnoreCase` + `ToUpperInvariant` + a custom `SetCollectorComparer` was doing the same job three times. Now set codes are canonical-uppercase by construction (normalized in `ReferenceCard.CreateFromScryfall`); the catalog dicts use default comparers; the custom tuple comparer is gone; `FindBy*` methods normalize input once at the entry point.

### CS0236 build error fix
`_selectedOutputFormat`'s field initializer referenced `_selectedInputFormat` — invalid per the C# spec. The `dotnet test` path doesn't compile the Blazor project, so this hid in `develop`. A full `dotnet build` fails on it. The bot warned about this on PR #74 and I dismissed it as theoretical; it wasn't. Moved both default-initializations to `OnInitialized` as the bot originally suggested.

### `_doubleFacedNames` / `IsDoubleFacedName` removed
No production callers — only test exposure. Front-face index alone covers all DFC handling.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test` — 164/164 pass locally (including new `Mtgo_AllRowsParse_*` end-to-end test that proves the 7-row fixture parses with `116/350` → `116` stripping and `MI` → `MIR` aliasing)
- [x] `FormatDetectorTests.DetectsKnownFormatsFromTheirHeaders` and `DetectsRealFixtureFiles` both gain MTGO assertions
- [ ] **CI caveat:** the `.NET` workflow has been failing on every recent run (pre-existing — the workflow doesn't regenerate the bundle and `CatalogFixture` errors out without it). My new test inherits this gap; locally it passes against the regenerated bundle. Worth a separate fix to either commit the bundle or have `.NET` workflow regenerate it.

## Note on bundle regeneration

The bundle (`MtgCsvHelper.BlazorWebAssembly/wwwroot/data/cards.min.json.gz`) is gitignored. To pick up the new `mtgo_code` data, run:

```bash
dotnet run --project tools/MtgCsvHelper.RefreshReferenceData -c Release
```

The `github-pages` workflow does this automatically on each release.

## Out of scope

- Deckbox set-code aliasing (#31) — the 7 remaining Deckbox fixture errors
- Tri-state Foil enum (#68) — `Premium` column currently maps to `bool? Foil`