### PR TITLE
CI: build + test on develop, cache the catalog bundle

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,6 +23,8 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
+    - name: Install .NET WASM Build Tools
+      run: dotnet workload install wasm-tools
     - name: Restore dependencies
       run: dotnet restore
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Refresh reference catalog (cache miss only)
       if: steps.bundle-cache.outputs.cache-hit != 'true'
-      run: dotnet run --project tools/MtgCsvHelper.RefreshReferenceData -c Release
+      run: dotnet run --project tools/MtgCsvHelper.RefreshReferenceData -c Release --no-restore
 
     - name: Build
       run: dotnet build --no-restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,13 +1,16 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+# Builds + tests on main and develop, plus PRs targeting either.
+# The reference-card bundle (cards.min.json.gz) is gitignored; the test fixture loads it,
+# so CI must either restore it from cache or regenerate from Scryfall. We cache by the hash
+# of the generator + model files — regen only fires when one of those changes, which is
+# also exactly when a fresh bundle is required.
 
 name: .NET
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
 
 jobs:
   build:
@@ -22,6 +25,18 @@ jobs:
         dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore
+
+    - name: Cache reference catalog bundle
+      id: bundle-cache
+      uses: actions/cache@v4
+      with:
+        path: MtgCsvHelper.BlazorWebAssembly/wwwroot/data/cards.min.json.gz
+        key: catalog-bundle-${{ hashFiles('tools/MtgCsvHelper.RefreshReferenceData/**', 'MtgCsvHelper/ReferenceCard.cs', 'MtgCsvHelper/ScryfallCardJson.cs') }}
+
+    - name: Refresh reference catalog (cache miss only)
+      if: steps.bundle-cache.outputs.cache-hit != 'true'
+      run: dotnet run --project tools/MtgCsvHelper.RefreshReferenceData -c Release
+
     - name: Build
       run: dotnet build --no-restore
     - name: Test


### PR DESCRIPTION
## Summary

Two related changes to [`.github/workflows/dotnet.yml`](https://github.com/StepKie/MtgCsvHelper/blob/develop/.github/workflows/dotnet.yml):

1. **Trigger on develop too** — was main-only. Develop merges have been shipping without ever running `.NET` build/test, which is exactly how the CS0236 Blazor compile-error in #74 reached develop (caught only later on a full local build).
2. **Cache the reference-card bundle** keyed on `hashFiles('tools/MtgCsvHelper.RefreshReferenceData/**', 'MtgCsvHelper/ReferenceCard.cs', 'MtgCsvHelper/ScryfallCardJson.cs')`. The bundle is gitignored; `CatalogFixture` needs it; previous runs had to either commit binaries or always download ~540MB from Scryfall. Now: cache hit → instant; cache miss → regen — and miss only happens when the generator or model code actually changed, which is precisely when a fresh bundle is needed.

## Trade-offs

- Cache hit path adds ~5s (restore step). Total CI run essentially unchanged.
- Cache miss path runs the generator (~2-3 min Scryfall download + parse). Same cost as the old failing-by-default path.
- Cache storage: ~10MB per entry, well under GitHub's 10GB-per-repo limit.

## Test plan

- [ ] Watch this PR's `.NET` workflow run go green (first run will populate the cache).
- [ ] Push a no-op commit after the first run to confirm cache-hit path is fast.

## Follow-ups (out of scope here)

- Weekly cache invalidation if we want fresh Scryfall data even without generator changes. Skip until it bites.