### PR TITLE
CI hotfix: revert --no-restore on generator run

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,7 +37,9 @@ jobs:
 
     - name: Refresh reference catalog (cache miss only)
       if: steps.bundle-cache.outputs.cache-hit != 'true'
-      run: dotnet run --project tools/MtgCsvHelper.RefreshReferenceData -c Release --no-restore
+      # No --no-restore: tools/ project isn't in MtgCsvHelper.slnx, so the prior restore step
+      # doesn't cover it; letting `dotnet run` do its own restore is the simpler fix.
+      run: dotnet run --project tools/MtgCsvHelper.RefreshReferenceData -c Release
 
     - name: Build
       run: dotnet build --no-restore


### PR DESCRIPTION
## The bug

PR #77 added `--no-restore` to the bundle-regen step per a bot review suggestion. The PR's CI run hit a cached bundle from a previous run and **skipped the regen step entirely**, so `--no-restore` wasn't actually exercised — the PR went green and merged. The first post-merge develop push had no cache, ran the regen, and failed:

```
NETSDK1004: Assets file '…/tools/MtgCsvHelper.RefreshReferenceData/obj/project.assets.json' not found.
```

## Root cause

The `tools/MtgCsvHelper.RefreshReferenceData` project isn't in `MtgCsvHelper.slnx`. The workflow's `dotnet restore` step (no args, restores the solution) doesn't touch it. With `--no-restore` on `dotnet run`, the missing assets file breaks the build.

## Fix

Drop `--no-restore`. Let the generator's `dotnet run` do its own restore — same as the working `github-pages.yml` does. The 10-20s saving wasn't worth this fragility.

## Lessons

- Should have caught this when reviewing the bot's suggestion: the tool project's restore state isn't a given.
- A PR run that skips the only step a change exercises isn't actually validating the change. Worth bearing in mind for future bot suggestions touching CI steps that the cache short-circuits.