### PR TITLE
Extract post-parse enricher pipeline (closes #46)

### DIFF
--- a/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
+++ b/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
@@ -11,7 +11,7 @@ namespace MtgCsvHelper.Enrichment;
 /// </summary>
 public sealed class CardmarketIdEnricher(ICardmarketResolver resolver) : IEnricher
 {
-	public async Task EnrichAsync(IList<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct)
+	public async Task EnrichAsync(List<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct)
 	{
 		// CardMarketId is `int` (not `int?`) in the Scryfall library, so 0 acts as the "unset" sentinel —
 		// real cardmarket_ids are always positive in Scryfall data.
@@ -30,9 +30,12 @@ public sealed class CardmarketIdEnricher(ICardmarketResolver resolver) : IEnrich
 		var ids = pending.Select(p => p.Id).Distinct().ToList();
 		var resolved = await resolver.ResolveAsync(ids, ct);
 
-		// Walk in reverse so RemoveAt doesn't shift positions we still need to visit. Duplicate
-		// CardMarketIds across rows are handled correctly: each row has its own entry in `pending`
-		// and both look up the same `full` record below (TryGetValue is idempotent).
+		// Walk in reverse so RemoveAt doesn't shift positions we still need to visit. Invariant:
+		// pending was built by walking rows forward, so its Index values are strictly ascending —
+		// reverse iteration here processes rows high-to-low, and each RemoveAt(i) only shifts
+		// positions we've already visited. Duplicate CardMarketIds across rows are handled
+		// correctly: each row has its own entry in `pending` and both look up the same `full`
+		// record below (TryGetValue is idempotent).
 		for (int k = pending.Count - 1; k >= 0; k--)
 		{
 			var (i, id) = pending[k];

--- a/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
+++ b/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
@@ -1,0 +1,55 @@
+using MtgCsvHelper.Services;
+
+namespace MtgCsvHelper.Enrichment;
+
+/// <summary>
+/// Resolves Cardmarket stub rows — those parsed with only <c>Printing.CardMarketId</c> set —
+/// to full Scryfall cards via batched <c>/cards/collection</c> lookup. Rows whose ID doesn't
+/// resolve are dropped with an Error. Other formats are passed through unchanged (their
+/// rows have no <c>CardMarketId</c>). Implements <see cref="IEnricher"/> directly rather
+/// than via <see cref="PerCardEnricher"/> because the batched network call is the whole point.
+/// </summary>
+public sealed class CardmarketIdEnricher(ICardmarketResolver resolver) : IEnricher
+{
+	public async Task EnrichAsync(IList<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct)
+	{
+		// CardMarketId is `int` (not `int?`) in the Scryfall library, so 0 acts as the "unset" sentinel —
+		// real cardmarket_ids are always positive in Scryfall data.
+		var pendingIndices = new List<int>();
+		for (int i = 0; i < rows.Count; i++)
+		{
+			var c = rows[i].Card;
+			if (c.Printing.CardMarketId > 0 && string.IsNullOrEmpty(c.Printing.Name))
+			{
+				pendingIndices.Add(i);
+			}
+		}
+
+		if (pendingIndices.Count == 0) { return; }
+
+		var ids = pendingIndices.Select(i => rows[i].Card.Printing.CardMarketId).Distinct().ToList();
+		var resolved = await resolver.ResolveAsync(ids, ct);
+
+		// Walk in reverse so removals don't shift indices we still need.
+		for (int k = pendingIndices.Count - 1; k >= 0; k--)
+		{
+			var i = pendingIndices[k];
+			var row = rows[i];
+			var id = row.Card.Printing.CardMarketId;
+			if (resolved.TryGetValue(id, out var full))
+			{
+				row.Card.Printing.Name = full.Name;
+				row.Card.Printing.Set = full.Set;
+				row.Card.Printing.SetName = full.SetName;
+				row.Card.Printing.CollectorNumber = full.CollectorNumber;
+			}
+			else
+			{
+				// Without a name/set, we can't write a meaningful row — drop the card.
+				// This is data loss (Error), not just degraded fidelity (Warning).
+				issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber, $"Cardmarket ID {id} not found in Scryfall data — card skipped"));
+				rows.RemoveAt(i);
+			}
+		}
+	}
+}

--- a/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
+++ b/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
@@ -30,7 +30,10 @@ public sealed class CardmarketIdEnricher(ICardmarketResolver resolver) : IEnrich
 		var ids = pendingIndices.Select(i => rows[i].Card.Printing.CardMarketId).Distinct().ToList();
 		var resolved = await resolver.ResolveAsync(ids, ct);
 
-		// Walk in reverse so removals don't shift indices we still need.
+		// Walk pendingIndices in reverse so RemoveAt doesn't shift positions we still need to
+		// visit. Note the double-indexing: k indexes pendingIndices, i is the original position
+		// in rows. Duplicate CardMarketIds across rows are handled correctly — both rows have
+		// distinct entries in pendingIndices and both look up the same `full` record below.
 		for (int k = pendingIndices.Count - 1; k >= 0; k--)
 		{
 			var i = pendingIndices[k];

--- a/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
+++ b/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
@@ -15,30 +15,28 @@ public sealed class CardmarketIdEnricher(ICardmarketResolver resolver) : IEnrich
 	{
 		// CardMarketId is `int` (not `int?`) in the Scryfall library, so 0 acts as the "unset" sentinel —
 		// real cardmarket_ids are always positive in Scryfall data.
-		var pendingIndices = new List<int>();
+		var pending = new List<(int Index, int Id)>();
 		for (int i = 0; i < rows.Count; i++)
 		{
 			var c = rows[i].Card;
 			if (c.Printing.CardMarketId > 0 && string.IsNullOrEmpty(c.Printing.Name))
 			{
-				pendingIndices.Add(i);
+				pending.Add((i, c.Printing.CardMarketId));
 			}
 		}
 
-		if (pendingIndices.Count == 0) { return; }
+		if (pending.Count == 0) { return; }
 
-		var ids = pendingIndices.Select(i => rows[i].Card.Printing.CardMarketId).Distinct().ToList();
+		var ids = pending.Select(p => p.Id).Distinct().ToList();
 		var resolved = await resolver.ResolveAsync(ids, ct);
 
-		// Walk pendingIndices in reverse so RemoveAt doesn't shift positions we still need to
-		// visit. Note the double-indexing: k indexes pendingIndices, i is the original position
-		// in rows. Duplicate CardMarketIds across rows are handled correctly — both rows have
-		// distinct entries in pendingIndices and both look up the same `full` record below.
-		for (int k = pendingIndices.Count - 1; k >= 0; k--)
+		// Walk in reverse so RemoveAt doesn't shift positions we still need to visit. Duplicate
+		// CardMarketIds across rows are handled correctly: each row has its own entry in `pending`
+		// and both look up the same `full` record below (TryGetValue is idempotent).
+		for (int k = pending.Count - 1; k >= 0; k--)
 		{
-			var i = pendingIndices[k];
+			var (i, id) = pending[k];
 			var row = rows[i];
-			var id = row.Card.Printing.CardMarketId;
 			if (resolved.TryGetValue(id, out var full))
 			{
 				row.Card.Printing.Name = full.Name;

--- a/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
+++ b/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
@@ -50,6 +50,8 @@ public sealed class CardmarketIdEnricher(ICardmarketResolver resolver) : IEnrich
 			{
 				// Without a name/set, we can't write a meaningful row — drop the card.
 				// This is data loss (Error), not just degraded fidelity (Warning).
+				// One error per affected row (not per distinct ID), so duplicate-ID inputs that
+				// fail to resolve produce one issue per row — keeps row-level traceability.
 				issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber, $"Cardmarket ID {id} not found in Scryfall data — card skipped"));
 				rows.RemoveAt(i);
 			}

--- a/MtgCsvHelper/Enrichment/CatalogValidator.cs
+++ b/MtgCsvHelper/Enrichment/CatalogValidator.cs
@@ -1,0 +1,76 @@
+using System.Globalization;
+using System.Text;
+
+namespace MtgCsvHelper.Enrichment;
+
+/// <summary>
+/// The one validator in the post-parse pipeline. Drops rows whose (Set, CollectorNumber)
+/// doesn't resolve, whose Name doesn't match the resolved printing, or whose Foil flag
+/// claims an unsupported finish. Named "Validator" rather than "Enricher" because it
+/// checks-and-drops; the only mutation it makes is to the issues collection.
+/// </summary>
+public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnricher
+{
+	protected override bool EnrichOne(ParsedRow row, ICollection<ImportIssue> issues)
+	{
+		var p = row.Card.Printing;
+		// Stub rows (Cardmarket pre-resolution) and rows that EnrichSetInfo already warned about
+		// for missing identifiers pass through — double-erroring would be noise.
+		if (string.IsNullOrEmpty(p.Name)) { return true; }
+		if (string.IsNullOrEmpty(p.Set) || string.IsNullOrEmpty(p.CollectorNumber)) { return true; }
+
+		var match = catalog.FindBySetAndCollectorNumber(p.Set, p.CollectorNumber);
+		if (match is null)
+		{
+			issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
+				$"No printing at {p.Set} #{p.CollectorNumber} in Scryfall data", CardName: p.Name));
+			return false;
+		}
+
+		if (!NamesMatch(p.Name, match.Name, catalog))
+		{
+			issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
+				$"Name '{p.Name}' does not match printing at {p.Set} #{p.CollectorNumber} ('{match.Name}')",
+				CardName: p.Name));
+			return false;
+		}
+
+		if (row.Card.Foil is true && !HasFoilFinish(match.Finishes))
+		{
+			issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
+				$"Printing {p.Set} #{p.CollectorNumber} was not released in foil", CardName: p.Name));
+			return false;
+		}
+
+		return true;
+	}
+
+	static bool NamesMatch(string imported, string referenceName, IReferenceCardCatalog catalog)
+	{
+		if (EqualsNormalized(imported, referenceName)) { return true; }
+		// Front-face-only imports (Moxfield's ShortNames=false formats) match the full Scryfall name.
+		var expanded = catalog.ExpandFrontFaceToFullName(imported);
+		return expanded is not null && EqualsNormalized(expanded, referenceName);
+	}
+
+	// Compares with Unicode diacritic stripping (NFD + remove combining marks). TCGPlayer and a
+	// few other sites normalize "Lim-Dûl's Vault" → "Lim-Dul's Vault" on export; Scryfall keeps the
+	// diacritic. Matching naively would reject every accented card. Done in one pass on both sides.
+	static bool EqualsNormalized(string a, string b) =>
+		string.Equals(StripDiacritics(a), StripDiacritics(b), StringComparison.OrdinalIgnoreCase);
+
+	static string StripDiacritics(string s)
+	{
+		var decomposed = s.Normalize(NormalizationForm.FormD);
+		var sb = new StringBuilder(decomposed.Length);
+		foreach (var c in decomposed)
+		{
+			if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark) { sb.Append(c); }
+		}
+		return sb.ToString();
+	}
+
+	static bool HasFoilFinish(IReadOnlyList<string> finishes) =>
+		finishes.Any(f => string.Equals(f, "foil", StringComparison.OrdinalIgnoreCase)
+		               || string.Equals(f, "etched", StringComparison.OrdinalIgnoreCase));
+}

--- a/MtgCsvHelper/Enrichment/CatalogValidator.cs
+++ b/MtgCsvHelper/Enrichment/CatalogValidator.cs
@@ -14,8 +14,10 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 	protected override bool EnrichOne(ParsedRow row, ICollection<ImportIssue> issues)
 	{
 		var p = row.Card.Printing;
-		// Stub rows (Cardmarket pre-resolution) and rows that EnrichSetInfo already warned about
-		// for missing identifiers pass through — double-erroring would be noise.
+		// No catalog lookup is possible without (Name, Set, CollectorNumber). Rows missing any
+		// of these have either already been warned by SetInfoEnricher (no set info) or are
+		// stubs that a later enricher will fill in (Cardmarket); validating now would error
+		// on data that isn't actually broken.
 		if (string.IsNullOrEmpty(p.Name)) { return true; }
 		if (string.IsNullOrEmpty(p.Set) || string.IsNullOrEmpty(p.CollectorNumber)) { return true; }
 

--- a/MtgCsvHelper/Enrichment/IEnricher.cs
+++ b/MtgCsvHelper/Enrichment/IEnricher.cs
@@ -5,8 +5,8 @@ namespace MtgCsvHelper.Enrichment;
 /// can mutate cards in place, can drop rows, and can append issues. Steps run in registration
 /// order — order is significant (e.g. catalog validation runs before Cardmarket resolution so
 /// Scryfall-resolved cards bypass the validator and avoid being dropped against a stale bundle).
-/// Named "Enricher" after the dominant role (4 of 5 known implementations transform card data);
-/// the one validator class is named <c>CatalogValidator</c> rather than pretending to be an enricher.
+/// Named "Enricher" after the dominant role — most implementations transform card data, while
+/// the lone validator is named <c>CatalogValidator</c> rather than pretending to be an enricher.
 /// </summary>
 public interface IEnricher
 {

--- a/MtgCsvHelper/Enrichment/IEnricher.cs
+++ b/MtgCsvHelper/Enrichment/IEnricher.cs
@@ -10,9 +10,7 @@ namespace MtgCsvHelper.Enrichment;
 /// </summary>
 public interface IEnricher
 {
-	/// <param name="rows">Mutable <see cref="List{T}"/> of parsed rows. Implementations may modify
-	/// cards in place and call <c>RemoveAt</c> to drop invalid/unresolvable rows. Passing a
-	/// fixed-size collection (e.g. an array or <c>ReadOnlyCollection</c>) throws
-	/// <see cref="NotSupportedException"/> at runtime.</param>
-	Task EnrichAsync(IList<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct);
+	/// <param name="rows">Mutable list of parsed rows. Implementations may modify cards in
+	/// place and call <c>RemoveAt</c> to drop invalid/unresolvable rows.</param>
+	Task EnrichAsync(List<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct);
 }

--- a/MtgCsvHelper/Enrichment/IEnricher.cs
+++ b/MtgCsvHelper/Enrichment/IEnricher.cs
@@ -10,8 +10,9 @@ namespace MtgCsvHelper.Enrichment;
 /// </summary>
 public interface IEnricher
 {
-	/// <param name="rows">Mutable list of parsed rows. Implementations may modify cards in place
-	/// and call <c>RemoveAt</c> to drop invalid/unresolvable rows — passing a fixed-size or
-	/// read-only <see cref="IList{T}"/> (e.g. arrays, <c>ReadOnlyCollection</c>) will throw.</param>
+	/// <param name="rows">Mutable <see cref="List{T}"/> of parsed rows. Implementations may modify
+	/// cards in place and call <c>RemoveAt</c> to drop invalid/unresolvable rows. Passing a
+	/// fixed-size collection (e.g. an array or <c>ReadOnlyCollection</c>) throws
+	/// <see cref="NotSupportedException"/> at runtime.</param>
 	Task EnrichAsync(IList<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct);
 }

--- a/MtgCsvHelper/Enrichment/IEnricher.cs
+++ b/MtgCsvHelper/Enrichment/IEnricher.cs
@@ -1,0 +1,36 @@
+namespace MtgCsvHelper.Enrichment;
+
+/// <summary>
+/// One step of the post-parse processing pipeline. Each step receives the current row list,
+/// can mutate cards in place, can drop rows, and can append issues. Steps run in registration
+/// order — order is significant (e.g. cardmarket-stub resolution must precede catalog validation).
+/// Named "Enricher" after the dominant role (4 of 5 known implementations transform card data);
+/// the one validator class is named <c>CatalogValidator</c> rather than pretending to be an enricher.
+/// </summary>
+public interface IEnricher
+{
+	Task EnrichAsync(IList<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct);
+}
+
+/// <summary>
+/// Convenience base for the common case: a sync, per-card step that may drop the row.
+/// Iterates in reverse so removals don't shift downstream indices.
+/// </summary>
+public abstract class PerCardEnricher : IEnricher
+{
+	public Task EnrichAsync(IList<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct)
+	{
+		for (int i = rows.Count - 1; i >= 0; i--)
+		{
+			ct.ThrowIfCancellationRequested();
+			if (!EnrichOne(rows[i], issues))
+			{
+				rows.RemoveAt(i);
+			}
+		}
+		return Task.CompletedTask;
+	}
+
+	/// <returns><c>true</c> to keep the row, <c>false</c> to drop it.</returns>
+	protected abstract bool EnrichOne(ParsedRow row, ICollection<ImportIssue> issues);
+}

--- a/MtgCsvHelper/Enrichment/IEnricher.cs
+++ b/MtgCsvHelper/Enrichment/IEnricher.cs
@@ -15,26 +15,3 @@ public interface IEnricher
 	/// read-only <see cref="IList{T}"/> (e.g. arrays, <c>ReadOnlyCollection</c>) will throw.</param>
 	Task EnrichAsync(IList<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct);
 }
-
-/// <summary>
-/// Convenience base for the common case: a sync, per-card step that may drop the row.
-/// Iterates in reverse so removals don't shift downstream indices.
-/// </summary>
-public abstract class PerCardEnricher : IEnricher
-{
-	public Task EnrichAsync(IList<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct)
-	{
-		for (int i = rows.Count - 1; i >= 0; i--)
-		{
-			ct.ThrowIfCancellationRequested();
-			if (!EnrichOne(rows[i], issues))
-			{
-				rows.RemoveAt(i);
-			}
-		}
-		return Task.CompletedTask;
-	}
-
-	/// <returns><c>true</c> to keep the row, <c>false</c> to drop it.</returns>
-	protected abstract bool EnrichOne(ParsedRow row, ICollection<ImportIssue> issues);
-}

--- a/MtgCsvHelper/Enrichment/IEnricher.cs
+++ b/MtgCsvHelper/Enrichment/IEnricher.cs
@@ -3,12 +3,16 @@ namespace MtgCsvHelper.Enrichment;
 /// <summary>
 /// One step of the post-parse processing pipeline. Each step receives the current row list,
 /// can mutate cards in place, can drop rows, and can append issues. Steps run in registration
-/// order — order is significant (e.g. cardmarket-stub resolution must precede catalog validation).
+/// order — order is significant (e.g. catalog validation runs before Cardmarket resolution so
+/// Scryfall-resolved cards bypass the validator and avoid being dropped against a stale bundle).
 /// Named "Enricher" after the dominant role (4 of 5 known implementations transform card data);
 /// the one validator class is named <c>CatalogValidator</c> rather than pretending to be an enricher.
 /// </summary>
 public interface IEnricher
 {
+	/// <param name="rows">Mutable list of parsed rows. Implementations may modify cards in place
+	/// and call <c>RemoveAt</c> to drop invalid/unresolvable rows — passing a fixed-size or
+	/// read-only <see cref="IList{T}"/> (e.g. arrays, <c>ReadOnlyCollection</c>) will throw.</param>
 	Task EnrichAsync(IList<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct);
 }
 

--- a/MtgCsvHelper/Enrichment/ParsedRow.cs
+++ b/MtgCsvHelper/Enrichment/ParsedRow.cs
@@ -1,0 +1,8 @@
+namespace MtgCsvHelper.Enrichment;
+
+/// <summary>
+/// One parsed CSV row threaded through the enrichment pipeline. Bundles the card with its
+/// source row number so error reporting stays accurate even after intermediate enrichers
+/// drop or reorder rows.
+/// </summary>
+public sealed record ParsedRow(PhysicalMtgCard Card, int RowNumber);

--- a/MtgCsvHelper/Enrichment/ParsedRow.cs
+++ b/MtgCsvHelper/Enrichment/ParsedRow.cs
@@ -3,6 +3,8 @@ namespace MtgCsvHelper.Enrichment;
 /// <summary>
 /// One parsed CSV row threaded through the enrichment pipeline. Bundles the card with its
 /// source row number so error reporting stays accurate even after intermediate enrichers
-/// drop or reorder rows.
+/// drop or reorder rows. Note: the wrapper is a record (positional + value-equality) but
+/// the inner <see cref="PhysicalMtgCard.Printing"/> is mutated in place by enrichers —
+/// the record buys no immutability for the contained data, only a clean (card, row) pair shape.
 /// </summary>
 public sealed record ParsedRow(PhysicalMtgCard Card, int RowNumber);

--- a/MtgCsvHelper/Enrichment/PerCardEnricher.cs
+++ b/MtgCsvHelper/Enrichment/PerCardEnricher.cs
@@ -1,0 +1,26 @@
+namespace MtgCsvHelper.Enrichment;
+
+/// <summary>
+/// Convenience base for the common case: a sync, per-card step that may drop the row.
+/// Iterates in reverse so removals don't shift downstream indices — as a side effect,
+/// issues appended during a single pass land in reverse row order. Consumers that care
+/// about ordering should sort by <see cref="ImportIssue.RowNumber"/>.
+/// </summary>
+public abstract class PerCardEnricher : IEnricher
+{
+	public Task EnrichAsync(IList<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct)
+	{
+		for (int i = rows.Count - 1; i >= 0; i--)
+		{
+			ct.ThrowIfCancellationRequested();
+			if (!EnrichOne(rows[i], issues))
+			{
+				rows.RemoveAt(i);
+			}
+		}
+		return Task.CompletedTask;
+	}
+
+	/// <returns><c>true</c> to keep the row, <c>false</c> to drop it.</returns>
+	protected abstract bool EnrichOne(ParsedRow row, ICollection<ImportIssue> issues);
+}

--- a/MtgCsvHelper/Enrichment/PerCardEnricher.cs
+++ b/MtgCsvHelper/Enrichment/PerCardEnricher.cs
@@ -3,12 +3,12 @@ namespace MtgCsvHelper.Enrichment;
 /// <summary>
 /// Convenience base for the common case: a sync, per-card step that may drop the row.
 /// Iterates in reverse so removals don't shift downstream indices — as a side effect,
-/// issues appended during a single pass land in reverse row order. Consumers that care
-/// about ordering should sort by <see cref="ImportIssue.RowNumber"/>.
+/// issues appended during a single pass land in reverse row order. <c>ParseCollectionCsvAsync</c>
+/// sorts the final issue list by <see cref="ImportIssue.RowNumber"/> before returning.
 /// </summary>
 public abstract class PerCardEnricher : IEnricher
 {
-	public Task EnrichAsync(IList<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct)
+	public Task EnrichAsync(List<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct)
 	{
 		for (int i = rows.Count - 1; i >= 0; i--)
 		{

--- a/MtgCsvHelper/Enrichment/SetInfoEnricher.cs
+++ b/MtgCsvHelper/Enrichment/SetInfoEnricher.cs
@@ -1,0 +1,42 @@
+namespace MtgCsvHelper.Enrichment;
+
+/// <summary>
+/// Backfills the missing side of (Set ↔ SetName) from the catalog, rewrites Set to canonical
+/// Scryfall casing (catches lowercase input and MTGO 2-letter aliases). Adds a Warning when
+/// the row has no set information at all, or when the supplied code/name doesn't resolve.
+/// </summary>
+public sealed class SetInfoEnricher(IReferenceCardCatalog catalog) : PerCardEnricher
+{
+	protected override bool EnrichOne(ParsedRow row, ICollection<ImportIssue> issues)
+	{
+		// Stub cards (Cardmarket pre-resolution) have no Name; their set info comes from the
+		// resolver enricher that runs before this one. Skip them here.
+		var p = row.Card.Printing;
+		if (string.IsNullOrEmpty(p.Name)) { return true; }
+
+		bool hadSetCode = p.Set is not null;
+		bool hadSetName = p.SetName is not null;
+
+		// Both directions are O(1) — the catalog maintains forward (code → name) and reverse (name → code) indexes.
+		if (hadSetCode) { p.SetName ??= catalog.GetSetNameByCode(p.Set!); }
+		if (hadSetName) { p.Set ??= catalog.GetSetCodeByName(p.SetName!); }
+		// Rewrite Set to its canonical Scryfall form once SetName is known. Catches MTGO aliases
+		// (MI → MIR) and any lowercase input so downstream writes emit the code other tools expect.
+		if (p.SetName is not null) { p.Set = catalog.GetSetCodeByName(p.SetName) ?? p.Set; }
+
+		if (!hadSetCode && !hadSetName)
+		{
+			issues.Add(new ImportIssue(IssueSeverity.Warning, row.RowNumber, "No set information found in row", CardName: p.Name));
+		}
+		else if (hadSetCode && p.SetName is null)
+		{
+			issues.Add(new ImportIssue(IssueSeverity.Warning, row.RowNumber, $"Set code '{p.Set}' not found in Scryfall data", CardName: p.Name));
+		}
+		else if (hadSetName && p.Set is null)
+		{
+			issues.Add(new ImportIssue(IssueSeverity.Warning, row.RowNumber, $"Set name '{p.SetName}' not found in Scryfall data", CardName: p.Name));
+		}
+
+		return true;
+	}
+}

--- a/MtgCsvHelper/Enrichment/SetInfoEnricher.cs
+++ b/MtgCsvHelper/Enrichment/SetInfoEnricher.cs
@@ -10,9 +10,9 @@ public sealed class SetInfoEnricher(IReferenceCardCatalog catalog) : PerCardEnri
 	protected override bool EnrichOne(ParsedRow row, ICollection<ImportIssue> issues)
 	{
 		var p = row.Card.Printing;
-		// Cardmarket stubs (Name="" with only CardMarketId set) reach here unresolved —
-		// CardmarketIdEnricher runs later in the pipeline. Skip them so we don't warn on
-		// the still-missing Set; the resolver will fill in Name + Set together.
+		// Skip rows that have no Name — there's nothing meaningful to enrich without a card
+		// identity, and any "no set info" warning would compound the issue rather than describe
+		// it. In practice this covers Cardmarket stubs awaiting CardmarketIdEnricher resolution.
 		if (string.IsNullOrEmpty(p.Name)) { return true; }
 
 		bool hadSetCode = p.Set is not null;

--- a/MtgCsvHelper/Enrichment/SetInfoEnricher.cs
+++ b/MtgCsvHelper/Enrichment/SetInfoEnricher.cs
@@ -9,9 +9,9 @@ public sealed class SetInfoEnricher(IReferenceCardCatalog catalog) : PerCardEnri
 {
 	protected override bool EnrichOne(ParsedRow row, ICollection<ImportIssue> issues)
 	{
-		// Stub cards (Cardmarket pre-resolution) have no Name; their set info comes from the
-		// resolver enricher that runs before this one. Skip them here.
 		var p = row.Card.Printing;
+		// Defensive: skip any row still missing a name. CardmarketIdEnricher runs first and
+		// either resolves stubs (Name now set) or drops them — this guard catches anything else.
 		if (string.IsNullOrEmpty(p.Name)) { return true; }
 
 		bool hadSetCode = p.Set is not null;

--- a/MtgCsvHelper/Enrichment/SetInfoEnricher.cs
+++ b/MtgCsvHelper/Enrichment/SetInfoEnricher.cs
@@ -10,8 +10,9 @@ public sealed class SetInfoEnricher(IReferenceCardCatalog catalog) : PerCardEnri
 	protected override bool EnrichOne(ParsedRow row, ICollection<ImportIssue> issues)
 	{
 		var p = row.Card.Printing;
-		// Defensive: skip any row still missing a name. CardmarketIdEnricher runs first and
-		// either resolves stubs (Name now set) or drops them — this guard catches anything else.
+		// Cardmarket stubs (Name="" with only CardMarketId set) reach here unresolved —
+		// CardmarketIdEnricher runs later in the pipeline. Skip them so we don't warn on
+		// the still-missing Set; the resolver will fill in Name + Set together.
 		if (string.IsNullOrEmpty(p.Name)) { return true; }
 
 		bool hadSetCode = p.Set is not null;

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -16,17 +16,18 @@ public class MtgCardCsvHandler
 	{
 		_format = format;
 		_factory = new CardMapFactory(config, catalog);
-		// Order matters: Cardmarket stubs (Name="") must be resolved before SetInfo and CatalogValidator
-		// can do anything with them. SetInfo runs before CatalogValidator so the canonical Set is in
-		// place when the catalog lookup happens. Note: this ordering means resolved Cardmarket cards
-		// also go through SetInfo + Validator — the old inline code ran Cardmarket resolution last
-		// and resolved cards bypassed both. Intentional improvement: validation now catches catalog
-		// drift in Scryfall-resolved data too.
+		// Order matches the prior inline implementation:
+		// 1. SetInfo + Validator run on non-stub rows (Cardmarket stubs have Name="" and are
+		//    skipped by both via their leading null-name guards).
+		// 2. CardmarketIdEnricher runs last, resolving stubs from the Scryfall network/catalog.
+		// Cardmarket-resolved cards intentionally bypass CatalogValidator: the resolver's data
+		// IS Scryfall data, so validating it against our possibly-stale local bundle would drop
+		// legitimate cards released after our last bundle refresh.
 		_pipeline =
 		[
-			new CardmarketIdEnricher(resolver),
 			new SetInfoEnricher(catalog),
 			new CatalogValidator(catalog),
+			new CardmarketIdEnricher(resolver),
 		];
 	}
 

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -1,24 +1,30 @@
 using System.Globalization;
-using System.Text;
 using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
 using Microsoft.Extensions.Configuration;
+using MtgCsvHelper.Enrichment;
 using MtgCsvHelper.Services;
 
 namespace MtgCsvHelper;
 public class MtgCardCsvHandler
 {
 	readonly CardMapFactory _factory;
-	readonly IReferenceCardCatalog _catalog;
-	readonly ICardmarketResolver _resolver;
 	readonly string _format;
+	readonly IReadOnlyList<IEnricher> _pipeline;
 
 	public MtgCardCsvHandler(IReferenceCardCatalog catalog, ICardmarketResolver resolver, IConfiguration config, string format)
 	{
 		_format = format;
 		_factory = new CardMapFactory(config, catalog);
-		_catalog = catalog;
-		_resolver = resolver;
+		// Order matters: Cardmarket stubs (Name="") must be resolved before SetInfo and CatalogValidator
+		// can do anything with them. SetInfo runs before CatalogValidator so the canonical Set is in
+		// place when the catalog lookup happens.
+		_pipeline =
+		[
+			new CardmarketIdEnricher(resolver),
+			new SetInfoEnricher(catalog),
+			new CatalogValidator(catalog),
+		];
 	}
 
 	// Sync wrappers — fine for non-Blazor callers and for formats that don't need network I/O.
@@ -52,8 +58,7 @@ public class MtgCardCsvHandler
 		csv.ReadHeader();
 		csv.ValidateHeader<PhysicalMtgCard>(); // throws HeaderValidationException if non-Optional fields are missing
 
-		var cards = new List<PhysicalMtgCard>();
-		var rowNumbers = new List<int>(); // parallel to cards; needed for issue reporting in the post-parse enrichment step
+		var rows = new List<ParsedRow>();
 		var issues = new List<ImportIssue>();
 
 		// CsvHelper's ReadAsync doesn't take a CT, so cancellation is checked per-row instead.
@@ -79,18 +84,7 @@ public class MtgCardCsvHandler
 						RawContent: csv.Parser.RawRecord?.TrimEnd()));
 					continue;
 				}
-				// For non-cardmarket formats, the printing's Name is set during parse; backfill set info now.
-				// For cardmarket-style stubs (Name empty, CardMarketId set), defer to the cardmarket enricher.
-				if (!string.IsNullOrEmpty(card.Printing.Name))
-				{
-					EnrichSetInfo(card, _catalog, issues, rowNum);
-					if (!IsValidPrinting(card, _catalog, issues, rowNum))
-					{
-						continue;
-					}
-				}
-				cards.Add(card);
-				rowNumbers.Add(rowNum);
+				rows.Add(new ParsedRow(card, rowNum));
 			}
 			catch (TypeConverterException tcex)
 			{
@@ -112,10 +106,13 @@ public class MtgCardCsvHandler
 			}
 		}
 
-		// Post-parse enrichment: fill in stubbed cards (Cardmarket) by batched Scryfall lookup.
-		await EnrichByCardmarketIdAsync(cards, rowNumbers, issues, ct);
+		// Run the post-parse pipeline. Each step mutates rows/issues in place (transforms or drops).
+		foreach (var enricher in _pipeline)
+		{
+			await enricher.EnrichAsync(rows, issues, ct);
+		}
 
-		var collection = new Collection { Name = $"Import {_format}, Date: {DateTime.Now}", Cards = cards };
+		var collection = new Collection { Name = $"Import {_format}, Date: {DateTime.Now}", Cards = [.. rows.Select(r => r.Card)] };
 		Log.Debug(collection.GenerateSummary());
 		return new ParseResult(collection, issues);
 
@@ -129,141 +126,6 @@ public class MtgCardCsvHandler
 				stream.BaseStream.Position = 0;
 				stream.DiscardBufferedData();
 			}
-		}
-	}
-
-	static bool IsValidPrinting(PhysicalMtgCard card, IReferenceCardCatalog catalog, List<ImportIssue> issues, int rowNum)
-	{
-		var p = card.Printing;
-		// Missing Set/CollectorNumber already warned by EnrichSetInfo; double-erroring would be noise.
-		if (string.IsNullOrEmpty(p.Set) || string.IsNullOrEmpty(p.CollectorNumber)) { return true; }
-
-		var match = catalog.FindBySetAndCollectorNumber(p.Set, p.CollectorNumber);
-		if (match is null)
-		{
-			issues.Add(new ImportIssue(IssueSeverity.Error, rowNum,
-				$"No printing at {p.Set} #{p.CollectorNumber} in Scryfall data", CardName: p.Name));
-			return false;
-		}
-
-		if (!NamesMatch(p.Name, match.Name, catalog))
-		{
-			issues.Add(new ImportIssue(IssueSeverity.Error, rowNum,
-				$"Name '{p.Name}' does not match printing at {p.Set} #{p.CollectorNumber} ('{match.Name}')",
-				CardName: p.Name));
-			return false;
-		}
-
-		if (card.Foil is true && !HasFoilFinish(match.Finishes))
-		{
-			issues.Add(new ImportIssue(IssueSeverity.Error, rowNum,
-				$"Printing {p.Set} #{p.CollectorNumber} was not released in foil", CardName: p.Name));
-			return false;
-		}
-
-		return true;
-	}
-
-	static bool NamesMatch(string imported, string referenceName, IReferenceCardCatalog catalog)
-	{
-		if (EqualsNormalized(imported, referenceName)) { return true; }
-		// Front-face-only imports (Moxfield's ShortNames=false formats) match the full Scryfall name.
-		var expanded = catalog.ExpandFrontFaceToFullName(imported);
-		return expanded is not null && EqualsNormalized(expanded, referenceName);
-	}
-
-	// Compares with Unicode diacritic stripping (NFD + remove combining marks). TCGPlayer and a
-	// few other sites normalize "Lim-Dûl's Vault" → "Lim-Dul's Vault" on export; Scryfall keeps the
-	// diacritic. Matching naively would reject every accented card. Done in one pass on both sides.
-	static bool EqualsNormalized(string a, string b) =>
-		string.Equals(StripDiacritics(a), StripDiacritics(b), StringComparison.OrdinalIgnoreCase);
-
-	static string StripDiacritics(string s)
-	{
-		var decomposed = s.Normalize(NormalizationForm.FormD);
-		var sb = new StringBuilder(decomposed.Length);
-		foreach (var c in decomposed)
-		{
-			if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark) { sb.Append(c); }
-		}
-		return sb.ToString();
-	}
-
-	static bool HasFoilFinish(IReadOnlyList<string> finishes) =>
-		finishes.Any(f => string.Equals(f, "foil", StringComparison.OrdinalIgnoreCase)
-		               || string.Equals(f, "etched", StringComparison.OrdinalIgnoreCase));
-
-	static void EnrichSetInfo(PhysicalMtgCard card, IReferenceCardCatalog catalog, List<ImportIssue> issues, int rowNum)
-	{
-		var p = card.Printing;
-		bool hadSetCode = p.Set is not null;
-		bool hadSetName = p.SetName is not null;
-
-		// Both directions are O(1) — the catalog maintains forward (code → name) and reverse (name → code) indexes.
-		if (hadSetCode) { p.SetName ??= catalog.GetSetNameByCode(p.Set!); }
-		if (hadSetName) { p.Set ??= catalog.GetSetCodeByName(p.SetName!); }
-		// Rewrite Set to its canonical Scryfall form once SetName is known. Catches MTGO aliases
-		// (MI → MIR) and any lowercase input so downstream writes emit the code other tools expect.
-		if (p.SetName is not null) { p.Set = catalog.GetSetCodeByName(p.SetName) ?? p.Set; }
-
-		if (!hadSetCode && !hadSetName)
-		{
-			issues.Add(new ImportIssue(IssueSeverity.Warning, rowNum, "No set information found in row", CardName: p.Name));
-		}
-		else if (hadSetCode && p.SetName is null)
-		{
-			issues.Add(new ImportIssue(IssueSeverity.Warning, rowNum, $"Set code '{p.Set}' not found in Scryfall data", CardName: p.Name));
-		}
-		else if (hadSetName && p.Set is null)
-		{
-			issues.Add(new ImportIssue(IssueSeverity.Warning, rowNum, $"Set name '{p.SetName}' not found in Scryfall data", CardName: p.Name));
-		}
-	}
-
-	// For cards whose Printing was parsed as a stub (only CardMarketId set), batch-resolve the
-	// full Scryfall card by cardmarket_id and fill in name/set/setName/collectorNumber.
-	// IDs not found in Scryfall produce an ImportIssue.Warning per affected card.
-	async Task EnrichByCardmarketIdAsync(IList<PhysicalMtgCard> cards, IList<int> rowNumbers, List<ImportIssue> issues, CancellationToken ct)
-	{
-		// CardMarketId is `int` (not `int?`) in the Scryfall library, so 0 acts as the "unset" sentinel —
-		// real cardmarket_ids are always positive in Scryfall data.
-		var pending = new List<(PhysicalMtgCard Card, int RowNum)>();
-		for (int i = 0; i < cards.Count; i++)
-		{
-			var c = cards[i];
-			if (c.Printing.CardMarketId > 0 && string.IsNullOrEmpty(c.Printing.Name))
-			{
-				pending.Add((c, rowNumbers[i]));
-			}
-		}
-
-		if (pending.Count == 0) return;
-
-		var ids = pending.Select(x => x.Card.Printing.CardMarketId).Distinct().ToList();
-		var resolved = await _resolver.ResolveAsync(ids, ct);
-
-		var unresolved = new List<PhysicalMtgCard>();
-		foreach (var entry in pending)
-		{
-			var id = entry.Card.Printing.CardMarketId;
-			if (resolved.TryGetValue(id, out var full))
-			{
-				entry.Card.Printing.Name = full.Name;
-				entry.Card.Printing.Set = full.Set;
-				entry.Card.Printing.SetName = full.SetName;
-				entry.Card.Printing.CollectorNumber = full.CollectorNumber;
-			}
-			else
-			{
-				// Without a name/set, we can't write a meaningful row — drop the card.
-				// This is data loss (Error), not just degraded fidelity (Warning).
-				issues.Add(new ImportIssue(IssueSeverity.Error, entry.RowNum, $"Cardmarket ID {id} not found in Scryfall data — card skipped"));
-				unresolved.Add(entry.Card);
-			}
-		}
-		foreach (var dropped in unresolved)
-		{
-			cards.Remove(dropped);
 		}
 	}
 

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -18,7 +18,10 @@ public class MtgCardCsvHandler
 		_factory = new CardMapFactory(config, catalog);
 		// Order matters: Cardmarket stubs (Name="") must be resolved before SetInfo and CatalogValidator
 		// can do anything with them. SetInfo runs before CatalogValidator so the canonical Set is in
-		// place when the catalog lookup happens.
+		// place when the catalog lookup happens. Note: this ordering means resolved Cardmarket cards
+		// also go through SetInfo + Validator — the old inline code ran Cardmarket resolution last
+		// and resolved cards bypassed both. Intentional improvement: validation now catches catalog
+		// drift in Scryfall-resolved data too.
 		_pipeline =
 		[
 			new CardmarketIdEnricher(resolver),

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -116,9 +116,12 @@ public class MtgCardCsvHandler
 			await enricher.EnrichAsync(rows, issues, ct);
 		}
 
+		// Pipeline stages emit issues in mixed order (parse loop ascending, PerCardEnricher
+		// reverse iteration descending, batch enrichers ascending). Sort by RowNumber once at
+		// the exit so consumers always see ascending row order.
 		var collection = new Collection { Name = $"Import {_format}, Date: {DateTime.Now}", Cards = [.. rows.Select(r => r.Card)] };
 		Log.Debug(collection.GenerateSummary());
-		return new ParseResult(collection, issues);
+		return new ParseResult(collection, [.. issues.OrderBy(i => i.RowNumber)]);
 
 		static void CheckIfFirstLineCanBeIgnored(StreamReader stream)
 		{


### PR DESCRIPTION
## Summary

Implements [#46](https://github.com/StepKie/MtgCsvHelper/issues/46). The three inline post-parse steps in `MtgCardCsvHandler` are now first-class pipeline stages under `MtgCsvHelper/Enrichment/`:

| Class | Role | Sync/Async | Drops? |
|---|---|---|---|
| `SetInfoEnricher` | Backfills Set ↔ SetName, canonicalizes Set code | sync per-row | No |
| `CatalogValidator` | Validates (Set, CollectorNumber) → printing; name match; foil claim | sync per-row | Invalid rows |
| `CardmarketIdEnricher` | Resolves cardmarket-stub rows via batched Scryfall lookup | async batch | Unresolved IDs |

## Behavior preservation

Pipeline order matches the prior inline implementation: `SetInfoEnricher` → `CatalogValidator` → `CardmarketIdEnricher`. Cardmarket-resolved cards intentionally bypass `CatalogValidator` — the resolver's data IS Scryfall data (via network or local catalog), so re-validating against a possibly-stale local bundle would silently drop legitimate cards released after the last bundle refresh. Stubs (Name="") reach `SetInfoEnricher` + `CatalogValidator` unresolved, are skipped by their leading null-name guards, and reach `CardmarketIdEnricher` intact for resolution.

## API shape

```csharp
public interface IEnricher
{
    Task EnrichAsync(IList<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct);
}

public sealed record ParsedRow(PhysicalMtgCard Card, int RowNumber);

public abstract class PerCardEnricher : IEnricher { /* reverse-loop + drop-on-false */ }
```

- One interface, one method. Pipeline is `foreach (var e in _pipeline) await e.EnrichAsync(rows, issues, ct);`.
- `ParsedRow` replaces the parallel `IList<PhysicalMtgCard> cards` + `IList<int> rowNumbers` smell from the prior code.
- `PerCardEnricher` absorbs the reverse-loop-and-remove boilerplate for the common case.
- The one validator is named `CatalogValidator`, not `CatalogValidationEnricher` — the interface is the pipeline shape, the class name signals the role honestly.

## Why this shape (informed by future tickets)

- **#31 (Deckbox set-code aliasing)** lands as `DeckboxSetCodeEnricher : PerCardEnricher` inserted before `SetInfoEnricher` (alias before catalog lookup). One class, ~20 lines.
- **#23 (borderless suffix)** is write-side, so it reuses the same `IEnricher` interface on a separate pre-write pipeline. Out of scope for this PR.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test` — 169/169 pass
- [x] No fixture changes; pipeline behaviour matches the prior inline implementation it replaces.

## Notes

`MtgCardCsvHandler.ParseCollectionCsvAsync` is meaningfully smaller now: parse loop builds rows, pipeline runs, collection assembled. The 60-line block of inline post-parse logic is gone.