### PR TITLE
Fix Blazor app dropping appsettings.json from publish manifest (#82)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,7 +370,6 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 MtgCsvHelper.BlazorWebAssembly/wwwroot/README.md
-MtgCsvHelper.BlazorWebAssembly/wwwroot/appsettings.json
 
 # VS Code workspace file
 *.code-workspace

--- a/MtgCsvHelper.BlazorWebAssembly/MtgCsvHelper.BlazorWebAssembly.csproj
+++ b/MtgCsvHelper.BlazorWebAssembly/MtgCsvHelper.BlazorWebAssembly.csproj
@@ -38,6 +38,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Update="wwwroot\appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
     <Content Update="wwwroot\appsettings.Development.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
@@ -50,10 +55,13 @@
     <Copy SourceFiles="..\README.md" DestinationFolder="wwwroot" />
   </Target>
 
-  <!-- Stage MtgCsvHelper/appsettings.json into wwwroot before the static-web-asset pipeline
-       so Blazor serves the canonical single-source-of-truth config. The copy is gitignored
-       at wwwroot/appsettings.json so the duplicate doesn't sneak back into the repo. -->
-  <Target Name="StageAppsettings" BeforeTargets="ResolveStaticWebAssetsInputs;BeforeBuild">
+  <!-- Keep wwwroot/appsettings.json in sync with the canonical MtgCsvHelper/appsettings.json
+       used by Console and Tests. The wwwroot copy is committed (so the static-web-asset
+       pipeline picks it up at evaluation time — a build-time-only stage misses fresh CI
+       checkouts and silently drops the file from the service-worker manifest). SkipUnchanged
+       makes the copy a no-op when content already matches; an out-of-sync edit shows up in
+       `git status` and is committed alongside the source change. -->
+  <Target Name="SyncAppsettings" BeforeTargets="BeforeBuild">
     <Copy SourceFiles="..\MtgCsvHelper\appsettings.json"
           DestinationFiles="wwwroot\appsettings.json"
           SkipUnchangedFiles="true" />

--- a/MtgCsvHelper.BlazorWebAssembly/wwwroot/appsettings.json
+++ b/MtgCsvHelper.BlazorWebAssembly/wwwroot/appsettings.json
@@ -1,0 +1,431 @@
+{
+  "CsvConfigurations": [
+    {
+      "Name": "DRAGONSHIELD",
+      "Quantity": "Quantity",
+      "CardName": {
+        "HeaderName": "Card Name",
+        "ShortNames": true,
+        "EncodeToken": true
+      },
+      "SetCode": "Set Code",
+      "SetName": "Set Name",
+      "SetNumber": "Card Number",
+      "Finish": {
+        "HeaderName": "Printing",
+        "Normal": "Normal",
+        "Foil": "Foil",
+        "Etched": null
+      },
+      "Condition": {
+        "HeaderName": "Condition",
+        "Mint": "Mint",
+        "NearMint": "NearMint",
+        "Excellent": "Excellent",
+        "Good": "Good",
+        "LightlyPlayed": "LightPlayed",
+        "Played": "Played",
+        "Poor": "Poor"
+      },
+        "Language": {
+            "HeaderName": "Language",
+            "Mappings": {
+                "en": "English",
+                "es": "Spanish",
+                "fr": "French",
+                "de": "German",
+                "it": "Italian",
+                "pt": "Portuguese",
+                "ja": "Japanese",
+                "ko": "Korean",
+                "ru": "Russian",
+                "zhs": "Chinese",
+                "zht": "Traditional Chinese"
+            }
+        },
+      "PriceBought": {
+        "HeaderName": "Price Bought",
+        "Currency": "USD",
+        "CurrencySymbol": "Absent"
+      },
+      "DateBought": "Date Bought"
+    },
+    {
+      "Name": "MOXFIELD",
+      "Quantity": "Count",
+      "CardName": {
+        "HeaderName": "Name",
+        "ShortNames": false
+      },
+      "SetCode": "Edition",
+      "SetName": null,
+      "SetNumber": "Collector Number",
+      "Finish": {
+        "HeaderName": "Foil",
+        "Normal": "",
+        "Foil": "foil",
+        "Etched": "etched"
+      },
+      "Condition": {
+        "HeaderName": "Condition",
+        "Mint": "Mint",
+        "NearMint": "Near Mint",
+        "Excellent": null,
+        "Good": "Good (Lightly Played)",
+        "LightlyPlayed": "Played",
+        "Played": "Heavily Played",
+        "Poor": "Damaged"
+      },
+        "Language": {
+            "HeaderName": "Language",
+            "Mappings": {
+                "en": "English",
+                "es": "Spanish",
+                "fr": "French",
+                "de": "German",
+                "it": "Italian",
+                "pt": "Portuguese",
+                "ja": "Japanese",
+                "ko": "Korean",
+                "ru": "Russian",
+                "zhs": "Chinese",
+                "zht": "Traditional Chinese"
+            }
+        },
+      "PriceBought": {
+        "HeaderName": "Purchase Price",
+        "Currency": "EUR",
+        "CurrencySymbol": "Absent"
+      }
+    },
+    {
+      "Name": "MANABOX",
+      "Quantity": "Quantity",
+      "CardName": {
+        "HeaderName": "Name",
+        "ShortNames": false
+      },
+      "SetCode": "Set code",
+      "SetName": "Set name",
+      "SetNumber": "Collector number",
+      "Finish": {
+        "HeaderName": "Foil",
+        "Normal": "normal",
+        "Foil": "foil",
+        "Etched": "etched"
+      },
+      "Condition": {
+        "HeaderName": "Condition",
+        "Mint": "mint",
+        "NearMint": "near_mint",
+        "Excellent": "excellent",
+        "Good": "good",
+        "LightlyPlayed": "light_played",
+        "Played": "played",
+        "Poor": "poor"
+      },
+        "Language": {
+            "HeaderName": "Language",
+            "Mappings": {
+                "en": "en",
+                "es": "es",
+                "fr": "fr",
+                "de": "de",
+                "it": "it",
+                "pt": "pt",
+                "ja": "ja",
+                "ko": "ko",
+                "ru": "ru",
+                "zhs": "zh_CN",
+                "zht": "zh_TW"
+            }
+        },
+      "PriceBought": {
+        "HeaderName": "Purchase price",
+        "Currency": "USD",
+        "CurrencySymbol": "Absent"
+      }
+    },
+    {
+      "Name": "TOPDECKED",
+      "Quantity": "QUANTITY",
+      "CardName": {
+        "HeaderName": "NAME",
+        "ShortNames": false
+      },
+      "SetCode": "SETCODE",
+      "SetName": "SETNAME",
+      "SetNumber": "COLLECTOR NUMBER",
+      "Finish": {
+        "HeaderName": "FINISH",
+        "Normal": "nonfoil",
+        "Foil": "foil",
+        "Etched": "etched"
+      },
+      "Condition": {
+        "HeaderName": "CONDITION",
+        "Mint": "mint",
+        "NearMint": "near mint",
+        "Excellent": null,
+        "Good": "slightly played",
+        "LightlyPlayed": "moderately played",
+        "Played": "heavily played",
+        "Poor": "damaged"
+      },
+        "Language": {
+            "HeaderName": "LANG",
+            "Mappings": {
+                "en": "en",
+                "es": "es",
+                "fr": "fr",
+                "de": "de",
+                "it": "it",
+                "pt": "pt",
+                "ja": "ja",
+                "ko": "ko",
+                "ru": "ru",
+                "zhs": "zhs",
+                "zht": "zht"
+            }
+        },
+      "PriceBought": {
+        "HeaderName": "ACQUIRED PRICE",
+        "Currency": "USD",
+        "CurrencySymbol": "Absent"
+      }
+    },
+    {
+      "Name": "DECKBOX",
+      "Quantity": "Count",
+      "CardName": {
+        "HeaderName": "Name",
+        "ShortNames": false
+      },
+      "SetCode": "Edition Code",
+      "SetName": "Edition",
+      "SetNumber": "Card Number",
+      "Finish": {
+        "HeaderName": "Foil",
+        "Normal": "",
+        "Foil": "foil",
+        "Etched": "etched"
+      },
+      "Condition": {
+        "HeaderName": "Condition",
+        "Mint": "Mint",
+        "NearMint": "Near Mint",
+        "Excellent": null,
+        "Good": "Good (Lightly Played)",
+        "LightlyPlayed": "Played",
+        "Played": "Heavily Played",
+        "Poor": "Poor"
+      },
+        "Language": {
+            "HeaderName": "Language",
+            "Mappings": {
+                "en": "English",
+                "es": "Spanish",
+                "fr": "French",
+                "de": "German",
+                "it": "Italian",
+                "pt": "Portuguese",
+                "ja": "Japanese",
+                "ko": "Korean",
+                "ru": "Russian",
+                "zhs": "Chinese",
+                "zht": "Traditional Chinese"
+            }
+        },
+      "PriceBought": {
+        "HeaderName": "My Price",
+        "Currency": "USD",
+        "CurrencySymbol": "Start"
+      }
+    },
+    {
+      "Name": "TCGPLAYER",
+      "Quantity": "Quantity",
+      "CardName": {
+        "HeaderName": "Simple Name",
+        "ShortNames": true
+      },
+      "SetCode": "Set Code",
+      "SetName": "Set",
+      "SetNumber": "Card Number",
+      "Finish": {
+        "HeaderName": "Printing",
+        "Normal": "Normal",
+        "Foil": "Foil",
+        "Etched": null
+      },
+      "Condition": {
+        "HeaderName": "Condition",
+        "Mint": "Mint",
+        "NearMint": "Near Mint",
+        "Excellent": "Lightly Played",
+        "Good": "Lightly Played",
+        "LightlyPlayed": "Moderately Played",
+        "Played": "Heavily Played",
+        "Poor": "Damaged"
+      },
+        "Language": {
+            "HeaderName": "Language",
+            "Mappings": {
+                "en": "English",
+                "es": "Spanish",
+                "fr": "French",
+                "de": "German",
+                "it": "Italian",
+                "pt": "Portuguese",
+                "ja": "Japanese",
+                "ko": "Korean",
+                "ru": "Russian",
+                "zhs": "Chinese",
+                "zht": "Traditional Chinese"
+            }
+        }
+    },
+    {
+      "Name": "MTGGOLDFISH",
+      "Quantity": "Quantity",
+      "CardName": {
+        "HeaderName": "Card",
+        "ShortNames": true
+      },
+      "SetCode": "Set ID",
+      "SetName": "Set Name",
+      "SetNumber": "Collector Number",
+      "Finish": {
+        "HeaderName": "Foil",
+        "Normal": "regular",
+        "Foil": "foil",
+        "Etched": "foil_etched"
+      }
+    },
+    {
+      "Name": "ARCHIDEKT",
+      "Quantity": "Quantity",
+      "CardName": {
+        "HeaderName": "Name",
+        "ShortNames": false
+      },
+      "SetCode": "Edition Code",
+      "SetName": "Edition Name",
+      "SetNumber": "Collector Number",
+      "Finish": {
+        "HeaderName": "Finish",
+        "Normal": "Normal",
+        "Foil": "Foil",
+        "Etched": "Etched"
+      },
+      "Condition": {
+        "HeaderName": "Condition",
+        "Mint": null,
+        "NearMint": "NM",
+        "Excellent": null,
+        "Good": "LP",
+        "LightlyPlayed": "MP",
+        "Played": "HP",
+        "Poor": "D"
+      },
+      "Language": {
+        "HeaderName": "Language",
+        "Mappings": {
+          "en": "EN",
+          "es": "ES",
+          "fr": "FR",
+          "de": "DE",
+          "it": "IT",
+          "pt": "PT",
+          "ja": "JP",
+          "ko": "KR",
+          "ru": "RU",
+          "zhs": "CS",
+          "zht": "CT"
+        }
+      },
+      "PriceBought": {
+        "HeaderName": "Purchase Price",
+        "Currency": "USD",
+        "CurrencySymbol": "Absent"
+      },
+      "DateBought": "Date Added"
+    },
+    {
+      "Name": "MTGO",
+      "Quantity": "Quantity",
+      "CardName": {
+        "HeaderName": "Card Name",
+        "ShortNames": false
+      },
+      "SetCode": "Set",
+      "SetNumber": "Collector #",
+      "Finish": {
+        "HeaderName": "Premium",
+        "Normal": "No",
+        "Foil": "Yes",
+        "Etched": null
+      }
+    },
+    {
+      "Name": "CARDKINGDOM",
+      "Quantity": "quantity",
+      "CardName": {
+        "HeaderName": "title",
+        "ShortNames": true
+      },
+      "SetCode": null,
+      "SetName": "edition",
+      "SetNumber": null,
+      "Finish": {
+        "HeaderName": "foil",
+        "Normal": "FALSE",
+        "Foil": "TRUE",
+        "Etched": null
+      }
+    },
+    {
+      "Name": "CARDMARKET",
+      "Delimiter": ";",
+      "Quantity": "groupCount",
+      "CardmarketId": "idProduct",
+      "Finish": {
+        "HeaderName": "isFoil",
+        "Foil": "1",
+        "Normal": "",
+        "Etched": null
+      },
+      "Condition": {
+        "HeaderName": "condition",
+        "Mint": "1",
+        "NearMint": "2",
+        "Excellent": "3",
+        "Good": "4",
+        "LightlyPlayed": "5",
+        "Played": "6",
+        "Poor": "7"
+      },
+      "Language": {
+        "HeaderName": "idLanguage",
+        "Mappings": {
+          "en": "1",
+          "fr": "2",
+          "de": "3",
+          "es": "4",
+          "it": "5",
+          "zhs": "6",
+          "ja": "7",
+          "pt": "8",
+          "ru": "9",
+          "ko": "10",
+          "zht": "11"
+        }
+      },
+      "PriceBought": {
+        "HeaderName": "price",
+        "Currency": "EUR",
+        "CurrencySymbol": "Absent"
+      }
+    }
+  ]
+}

--- a/MtgCsvHelper.Tests/AppsettingsParityTests.cs
+++ b/MtgCsvHelper.Tests/AppsettingsParityTests.cs
@@ -1,0 +1,27 @@
+using System.Runtime.CompilerServices;
+
+namespace MtgCsvHelper.Tests;
+
+public class AppsettingsParityTests
+{
+	// MtgCsvHelper/appsettings.json is the library-side runtime config used by Console + Tests;
+	// MtgCsvHelper.BlazorWebAssembly/wwwroot/appsettings.json is the Blazor static-web-asset copy
+	// served to the browser. They must stay byte-identical — a divergence means Console and the
+	// deployed Blazor app would parse different format mappings for the same CSV file.
+	[Fact]
+	public void BlazorWwwrootCopy_IsByteIdenticalToLibrarySource()
+	{
+		var (library, wwwroot) = ResolvePaths();
+		File.ReadAllBytes(wwwroot).Should().Equal(File.ReadAllBytes(library),
+			because: "wwwroot/appsettings.json must mirror MtgCsvHelper/appsettings.json — the build-time sync target keeps them aligned; commit both files together.");
+	}
+
+	static (string Library, string Wwwroot) ResolvePaths([CallerFilePath] string? thisFile = null)
+	{
+		var repoRoot = new FileInfo(thisFile!).Directory!.Parent
+			?? throw new InvalidOperationException("Could not resolve repo root from test file path.");
+		return (
+			Path.Combine(repoRoot.FullName, "MtgCsvHelper", "appsettings.json"),
+			Path.Combine(repoRoot.FullName, "MtgCsvHelper.BlazorWebAssembly", "wwwroot", "appsettings.json"));
+	}
+}


### PR DESCRIPTION
## Summary

Closes #82.

PR #66's dedup mechanism — a build-time `Copy` target staging `MtgCsvHelper/appsettings.json` into `wwwroot/` — runs in MSBuild's **execution phase**, but the static-web-assets pipeline enumerates `wwwroot/` in **evaluation phase**. On a fresh CI checkout the gitignored staged copy doesn't exist yet, so the file ends up on the GH-Pages server but is **not** in the service-worker manifest and is **not** registered as a static web asset. The deployed Blazor runtime sees no `CsvConfigurations` and throws `Format 'DRAGONSHIELD' configuration not found.` on every conversion attempt (also reproduced as `Format 'MOXFIELD' …` in issue #82).

Local incremental builds didn't catch it because the staged file persisted on disk from previous runs — the very ["works on my machine"](https://en.wikipedia.org/wiki/Works_on_my_machine) shape that #74's filter-by-capability work was supposed to flush out.

**Evidence:**
- gh-pages 1.2.0 SW manifest: `"url": "appsettings.json"` ✅
- gh-pages 1.3.0 SW manifest: missing ❌
- Fresh-CI publish locally (`rm wwwroot/appsettings.json; dotnet publish -c:Release -p:GHPages=true`) reproduces the missing manifest entry

## Fix

- Commit `MtgCsvHelper.BlazorWebAssembly/wwwroot/appsettings.json` so the file exists at MSBuild evaluation phase. Restore the `<Content Update>` declaration that gives it the right `CopyToOutputDirectory` / `CopyToPublishDirectory` metadata.
- Rename `StageAppsettings` → `SyncAppsettings` and keep it: `MtgCsvHelper/appsettings.json` stays canonical, and the target syncs the wwwroot copy on every build (`SkipUnchangedFiles` makes it a no-op when content matches).
- `AppsettingsParityTests` asserts the two files are byte-identical, so drift fails CI before deploy.

## Test plan

- [ ] CI build + tests green
- [ ] `gh pr checks <this PR> --watch` shows checks complete
- [ ] After develop→main merge: visit https://stepkie.github.io/MtgCsvHelper/, hard-reload past the SW banner, import a Moxfield CSV → Dragon Shield. No "configuration not found".
- [ ] Verify `service-worker-assets.js` on the deployed site contains `"appsettings.json"`.