### PR TITLE
Show full row content of problematic entries in import-issue list (#91 part 1)

### DIFF
--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -237,16 +237,30 @@
 						@foreach (var g in grouped)
 						{
 							var (severity, reason) = g.Key;
-							var rows = g.Select(i => i.RowNumber).OrderBy(rowNum => rowNum).ToList();
-							var preview = string.Join(", ", rows.Take(8));
-							if (rows.Count > 8) preview += $", … (+{rows.Count - 8} more)";
+							var issues = g.OrderBy(i => i.RowNumber).ToList();
 							<MudListItem T="object" Icon="@(severity == IssueSeverity.Error ? Icons.Material.Filled.Error : Icons.Material.Filled.Warning)"
 							             IconColor="@(severity == IssueSeverity.Error ? Color.Error : Color.Warning)">
 								<MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
 									<MudText Typo="Typo.body2"><strong>@reason</strong></MudText>
-									<MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@g.Count() row@(g.Count() == 1 ? "" : "s")</MudChip>
+									<MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@issues.Count row@(issues.Count == 1 ? "" : "s")</MudChip>
 								</MudStack>
-								<MudText Typo="Typo.caption" Class="mud-text-secondary">@(rows.Count == 1 ? "row" : "rows"): @preview</MudText>
+								<div class="issue-row-list">
+									@foreach (var issue in issues.Take(MaxIssueRowsShown))
+									{
+										<div class="issue-row">
+											row @issue.RowNumber@if (!string.IsNullOrEmpty(issue.RawContent))
+											{
+												<text>: </text><code class="issue-row-raw">@issue.RawContent</code>
+											}
+										</div>
+									}
+									@if (issues.Count > MaxIssueRowsShown)
+									{
+										<MudText Typo="Typo.caption" Class="mud-text-secondary mt-1 d-block">
+											… and @(issues.Count - MaxIssueRowsShown) more (download the error report or report to GitHub for the full list)
+										</MudText>
+									}
+								</div>
 							</MudListItem>
 						}
 					</MudList>
@@ -346,6 +360,7 @@
 
 @code {
 	const int MaxFileSize = 5 * 1024 * 1024;
+	const int MaxIssueRowsShown = 25;
 	static readonly IReadOnlyList<string> _inputFormats = CardMapFactory.ReadableFormats;
 	static readonly IReadOnlyList<string> _outputFormats = CardMapFactory.WritableFormats;
 

--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor.css
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor.css
@@ -1,0 +1,25 @@
+/* Scoped to MtgCsvProcessor via Blazor CSS isolation. */
+
+/* Per-row detail block inside an Import-issue group. Shows the raw CSV row beneath the
+   reason in a muted, secondary-text color so it doesn't compete with the reason line.
+   Same tone as the "Source CSV formats are defined by third-party sites..." caption above. */
+.issue-row-list {
+	margin-top: 0.5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	color: var(--mud-palette-text-secondary);
+	font-size: 0.85rem;
+}
+
+.issue-row {
+	word-break: break-word;
+}
+
+.issue-row-raw {
+	font-family: ui-monospace, "Cascadia Code", Menlo, Consolas, monospace;
+	font-size: 0.8rem;
+	color: inherit;
+	background: none;
+	padding: 0;
+}

--- a/MtgCsvHelper.Tests/FaultToleranceTests.cs
+++ b/MtgCsvHelper.Tests/FaultToleranceTests.cs
@@ -26,6 +26,9 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 		result.ErrorCount.Should().Be(1);
 		result.Issues.Should().Contain(i => i.Severity == IssueSeverity.Warning && i.Reason.Contains("FAKESET"));
 		result.Issues.Should().Contain(i => i.Severity == IssueSeverity.Error && i.Reason.Contains("FAKESET"));
+		// RawContent must be threaded from the parse loop through both the SetInfoEnricher
+		// warning and the CatalogValidator error so the UI can show the offending row.
+		result.Issues.Should().AllSatisfy(i => i.RawContent.Should().Contain("Lightning Bolt").And.Contain("FAKESET"));
 	}
 
 	[Fact]
@@ -52,6 +55,7 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 		result.Collection.Cards.Should().BeEmpty();
 		result.ErrorCount.Should().Be(1);
 		result.Issues[0].Reason.Should().Contain("Fake Card Name").And.Contain("M11").And.Contain("#149");
+		result.Issues[0].RawContent.Should().Contain("Fake Card Name");
 	}
 
 	[Fact]
@@ -67,6 +71,7 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 		result.Collection.Cards.Should().BeEmpty();
 		result.ErrorCount.Should().Be(1);
 		result.Issues[0].Reason.Should().Contain("foil");
+		result.Issues[0].RawContent.Should().Contain("Lim-Dûl's Vault");
 	}
 
 	[Fact]
@@ -81,6 +86,25 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 		result.Collection.Cards.Should().BeEmpty();
 		result.ErrorCount.Should().Be(1);
 		result.Issues[0].Reason.Should().Contain("No printing").And.Contain("M11").And.Contain("9999");
+		result.Issues[0].RawContent.Should().Contain("9999");
+	}
+
+	[Fact]
+	public void NonPositiveCount_RaisesError_RowDropped_WithRawContent()
+	{
+		// Guards the parse-time RawContent capture (not the enricher pipeline). The Count
+		// validation runs inside the GetRecord try-block in MtgCardCsvHandler before the row
+		// reaches any enricher; if csv.Parser.RawRecord isn't captured there too the field is
+		// null on the emitted issue.
+		var csv = MoxHeader + "\n"
+			+ "0,Lightning Bolt,M11,149,,Near Mint,English,\n";
+
+		var result = Handler().ParseCollectionCsv(CsvStream(csv));
+
+		result.Collection.Cards.Should().BeEmpty();
+		result.ErrorCount.Should().Be(1);
+		result.Issues[0].Reason.Should().Contain("Count");
+		result.Issues[0].RawContent.Should().Contain("Lightning Bolt").And.StartWith("0,");
 	}
 
 	[Fact]

--- a/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
+++ b/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
@@ -53,7 +53,9 @@ public sealed class CardmarketIdEnricher(ICardmarketResolver resolver) : IEnrich
 				// This is data loss (Error), not just degraded fidelity (Warning).
 				// One error per affected row (not per distinct ID), so duplicate-ID inputs that
 				// fail to resolve produce one issue per row — keeps row-level traceability.
-				issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber, $"Cardmarket ID {id} not found in Scryfall data — card skipped"));
+				issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
+					$"Cardmarket ID {id} not found in Scryfall data — card skipped",
+					RawContent: row.RawContent));
 				rows.RemoveAt(i);
 			}
 		}

--- a/MtgCsvHelper/Enrichment/CatalogValidator.cs
+++ b/MtgCsvHelper/Enrichment/CatalogValidator.cs
@@ -25,7 +25,8 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 		if (match is null)
 		{
 			issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
-				$"No printing at {p.Set} #{p.CollectorNumber} in Scryfall data", CardName: p.Name));
+				$"No printing at {p.Set} #{p.CollectorNumber} in Scryfall data",
+				CardName: p.Name, RawContent: row.RawContent));
 			return false;
 		}
 
@@ -33,14 +34,15 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 		{
 			issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
 				$"Name '{p.Name}' does not match printing at {p.Set} #{p.CollectorNumber} ('{match.Name}')",
-				CardName: p.Name));
+				CardName: p.Name, RawContent: row.RawContent));
 			return false;
 		}
 
 		if (row.Card.Foil is true && !HasFoilFinish(match.Finishes))
 		{
 			issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
-				$"Printing {p.Set} #{p.CollectorNumber} was not released in foil", CardName: p.Name));
+				$"Printing {p.Set} #{p.CollectorNumber} was not released in foil",
+				CardName: p.Name, RawContent: row.RawContent));
 			return false;
 		}
 

--- a/MtgCsvHelper/Enrichment/ParsedRow.cs
+++ b/MtgCsvHelper/Enrichment/ParsedRow.cs
@@ -2,9 +2,10 @@ namespace MtgCsvHelper.Enrichment;
 
 /// <summary>
 /// One parsed CSV row threaded through the enrichment pipeline. Bundles the card with its
-/// source row number so error reporting stays accurate even after intermediate enrichers
-/// drop or reorder rows. Note: the wrapper is a record (positional + value-equality) but
-/// the inner <see cref="PhysicalMtgCard.Printing"/> is mutated in place by enrichers —
-/// the record buys no immutability for the contained data, only a clean (card, row) pair shape.
+/// source row number — and the raw CSV line it came from, so post-parse enrichers can include
+/// the raw text on any issues they emit (the UI surfaces it next to the row number for
+/// quick diagnosis). Note: the wrapper is a record (positional + value-equality) but the
+/// inner <see cref="PhysicalMtgCard.Printing"/> is mutated in place by enrichers — the
+/// record buys no immutability for the contained data, only a clean (card, row) pair shape.
 /// </summary>
-public sealed record ParsedRow(PhysicalMtgCard Card, int RowNumber);
+public sealed record ParsedRow(PhysicalMtgCard Card, int RowNumber, string? RawContent = null);

--- a/MtgCsvHelper/Enrichment/SetInfoEnricher.cs
+++ b/MtgCsvHelper/Enrichment/SetInfoEnricher.cs
@@ -32,15 +32,18 @@ public sealed class SetInfoEnricher(IReferenceCardCatalog catalog) : PerCardEnri
 
 		if (!hadSetCode && !hadSetName)
 		{
-			issues.Add(new ImportIssue(IssueSeverity.Warning, row.RowNumber, "No set information found in row", CardName: p.Name));
+			issues.Add(new ImportIssue(IssueSeverity.Warning, row.RowNumber, "No set information found in row",
+				CardName: p.Name, RawContent: row.RawContent));
 		}
 		else if (hadSetCode && p.SetName is null)
 		{
-			issues.Add(new ImportIssue(IssueSeverity.Warning, row.RowNumber, $"Set code '{p.Set}' not found in Scryfall data", CardName: p.Name));
+			issues.Add(new ImportIssue(IssueSeverity.Warning, row.RowNumber, $"Set code '{p.Set}' not found in Scryfall data",
+				CardName: p.Name, RawContent: row.RawContent));
 		}
 		else if (hadSetName && p.Set is null)
 		{
-			issues.Add(new ImportIssue(IssueSeverity.Warning, row.RowNumber, $"Set name '{p.SetName}' not found in Scryfall data", CardName: p.Name));
+			issues.Add(new ImportIssue(IssueSeverity.Warning, row.RowNumber, $"Set name '{p.SetName}' not found in Scryfall data",
+				CardName: p.Name, RawContent: row.RawContent));
 		}
 
 		return true;

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -76,6 +76,7 @@ public class MtgCardCsvHandler
 			}
 
 			int rowNum = csv.Parser.Row;
+			var rawContent = csv.Parser.RawRecord?.TrimEnd();
 			try
 			{
 				var card = csv.GetRecord<PhysicalMtgCard>();
@@ -85,10 +86,10 @@ public class MtgCardCsvHandler
 						IssueSeverity.Error,
 						rowNum,
 						$"Count must be positive (got {card.Count})",
-						RawContent: csv.Parser.RawRecord?.TrimEnd()));
+						RawContent: rawContent));
 					continue;
 				}
-				rows.Add(new ParsedRow(card, rowNum));
+				rows.Add(new ParsedRow(card, rowNum, rawContent));
 			}
 			catch (TypeConverterException tcex)
 			{
@@ -98,7 +99,7 @@ public class MtgCardCsvHandler
 					IssueSeverity.Error,
 					rowNum,
 					$"Invalid value '{value}' for column '{memberName}'",
-					RawContent: csv.Parser.RawRecord?.TrimEnd()));
+					RawContent: rawContent));
 			}
 			catch (Exception ex)
 			{
@@ -106,7 +107,7 @@ public class MtgCardCsvHandler
 					IssueSeverity.Error,
 					rowNum,
 					ex.Message,
-					RawContent: csv.Parser.RawRecord?.TrimEnd()));
+					RawContent: rawContent));
 			}
 		}
 


### PR DESCRIPTION
## Summary

Part 1 of #91. The "Correct this entry" Scryfall picker (part 2) is deferred to a follow-up PR — see #91 for scope.

**Before:** issue list showed only the *reason* + a comma list of row numbers. To see what was actually in row 3827 the user had to hop into a CSV editor.

**After:** each issue group lists every affected row as `row N: <raw csv content>` so the offending line is right there in the panel.

| | |
| --- | --- |
| `MtgCsvHelper/Enrichment/ParsedRow.cs` | Added `string? RawContent` to the record. Populated in `MtgCardCsvHandler` alongside the in-memory card. |
| `SetInfoEnricher.cs`, `CatalogValidator.cs`, `CardmarketIdEnricher.cs` | Pass `row.RawContent` to every `new ImportIssue(...)` so the per-row display has something to render for the post-parse failures. (Previously only parse-time issues — `Count must be positive`, `Invalid value for column X` — had it.) |
| `MtgCsvProcessor.razor` | Per-issue group now lists each affected row as `row N: <raw>` with the raw line inside a `<code>` block. Caps at 25 rows per group with "... and N more" caption. Guards against an empty `<code>` when `RawContent` is null. |
| `MtgCsvProcessor.razor.css` (new) | Scoped via Blazor CSS isolation. `.issue-row-list` is muted with `--mud-palette-text-secondary`; `.issue-row-raw` inherits color from the parent list item so warning/error rows keep their existing tint. Monospace for the raw content. |
| `MaxIssueRowsShown` | Hoisted to a `const` at the top of `@code` instead of inline in the `@foreach`. |

The early iteration of this PR had a regex-based highlight layer that wrapped offending values in `<mark>` tags + a separate `IssueHighlights` static class + 6 unit tests for it. After previewing the styled result locally, that whole layer was dropped — the raw row alone was good enough at this scope.

## Test plan

- [x] `dotnet test MtgCsvHelper.slnx` — 173 passing
- [x] `dotnet build` — clean, 0 warnings
- [x] Local dev-server verification: post-parse issues (MB1 / EMN / token name mismatches from the sample collections) now show the raw CSV row beneath the row number ✅
- [ ] CI green on this push

## Related issues (filed during diagnosis, with explicit permission)

- #92 — Catalog uses Scryfall `default_cards` so reprint set codes (MB1 etc.) don't resolve
- #93 — Dragon Shield decorates token names with parentheticals we don't strip
- #94 — Round-trip DFC names lose their back face when the front face is shared by multiple printings

All three are out of scope for this PR.