### PR TITLE
Hide Warnings on dropped rows in the import-issues panel

### DIFF
--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -196,10 +196,26 @@
 
 	@if (r.Issues.Count > 0)
 	{
-		var errorCount = r.Issues.Count(i => i.Severity == IssueSeverity.Error);
-		var warningCount = r.Issues.Count(i => i.Severity == IssueSeverity.Warning);
+		// Per-row deduplication: a row that ends up dropped (Error) often also collected a
+		// precondition Warning earlier in the pipeline (e.g. SetInfoEnricher's "Set code 'MB1'
+		// not found" + CatalogValidator's "No printing at MB1 #N"). Show only the most-severe
+		// issue per row — the Error already names the failure precisely; the Warning is just
+		// noise once we know the row was dropped. Chip counts are row-based for the same reason.
+		var rowsWithErrors = r.Issues
+			.Where(i => i.Severity == IssueSeverity.Error)
+			.Select(i => i.RowNumber)
+			.ToHashSet();
+		var displayedIssues = r.Issues
+			.Where(i => i.Severity == IssueSeverity.Error || !rowsWithErrors.Contains(i.RowNumber))
+			.ToList();
+		var errorCount = rowsWithErrors.Count;
+		var warningCount = displayedIssues
+			.Where(i => i.Severity == IssueSeverity.Warning)
+			.Select(i => i.RowNumber)
+			.Distinct()
+			.Count();
 		<MudExpansionPanels Class="mb-4" Elevation="1">
-			<MudExpansionPanel Expanded="@(r.Issues.Count <= 20)">
+			<MudExpansionPanel Expanded="@(displayedIssues.Count <= 20)">
 				<TitleContent>
 					<MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="flex-wrap">
 						<MudIcon Icon="@Icons.Material.Filled.Warning" Color="@(errorCount > 0 ? Color.Error : Color.Warning)" />
@@ -227,7 +243,7 @@
 						</MudStack>
 					}
 					@{
-						var grouped = r.Issues
+						var grouped = displayedIssues
 							.GroupBy(i => (i.Severity, i.Reason))
 							.OrderByDescending(g => g.Key.Severity == IssueSeverity.Error)
 							.ThenByDescending(g => g.Count())

--- a/MtgCsvHelper.Tests/SetInfoEnricherTests.cs
+++ b/MtgCsvHelper.Tests/SetInfoEnricherTests.cs
@@ -38,6 +38,27 @@ public class SetInfoEnricherTests(CatalogFixture fixture)
 	// (Moxfield / Manabox / Archidekt / TopDecked all emit canonical names), the catalog
 	// overwrite is a no-op. Documents the intended boundary so the "catalog always wins" rule
 	// can't silently degrade into "catalog overwrites with garbage when name lookup misfires".
+	[Fact]
+	public async Task EnrichAsync_AlreadyCanonicalSetName_PassesThroughUnchanged()
+	{
+		var row = new ParsedRow(new PhysicalMtgCard
+		{
+			Count = 1,
+			Printing = new Card
+			{
+				Name = "Ambitious Farmhand // Seasoned Cathar",
+				Set = "MID",
+				CollectorNumber = "2",
+				SetName = "Innistrad: Midnight Hunt",
+			},
+		}, RowNumber: 2);
+
+		await _enricher.EnrichAsync([row], [], CancellationToken.None);
+
+		row.Card.Printing.SetName.Should().Be("Innistrad: Midnight Hunt",
+			because: "a row that already carries the Scryfall canonical name must come out unchanged");
+	}
+
 	// Diagnostic — pinning the current behavior for an "MB1 + Mystery Booster" row whose
 	// set code is unknown to the catalog. Reported by user: both SetInfoEnricher emits a
 	// warning ("Set code 'MB1' not found") AND CatalogValidator emits an error
@@ -62,26 +83,5 @@ public class SetInfoEnricherTests(CatalogFixture fixture)
 
 		issues.Should().BeEmpty(
 			because: "the CSV supplied both a set code and a set name; SetInfoEnricher's role is to canonicalize against the catalog, not to flag every unknown set — CatalogValidator's downstream lookup will already emit a precise (Set, CollectorNumber) error.");
-	}
-
-	[Fact]
-	public async Task EnrichAsync_AlreadyCanonicalSetName_PassesThroughUnchanged()
-	{
-		var row = new ParsedRow(new PhysicalMtgCard
-		{
-			Count = 1,
-			Printing = new Card
-			{
-				Name = "Ambitious Farmhand // Seasoned Cathar",
-				Set = "MID",
-				CollectorNumber = "2",
-				SetName = "Innistrad: Midnight Hunt",
-			},
-		}, RowNumber: 2);
-
-		await _enricher.EnrichAsync([row], [], CancellationToken.None);
-
-		row.Card.Printing.SetName.Should().Be("Innistrad: Midnight Hunt",
-			because: "a row that already carries the Scryfall canonical name must come out unchanged");
 	}
 }

--- a/MtgCsvHelper.Tests/SetInfoEnricherTests.cs
+++ b/MtgCsvHelper.Tests/SetInfoEnricherTests.cs
@@ -38,6 +38,32 @@ public class SetInfoEnricherTests(CatalogFixture fixture)
 	// (Moxfield / Manabox / Archidekt / TopDecked all emit canonical names), the catalog
 	// overwrite is a no-op. Documents the intended boundary so the "catalog always wins" rule
 	// can't silently degrade into "catalog overwrites with garbage when name lookup misfires".
+	// Diagnostic — pinning the current behavior for an "MB1 + Mystery Booster" row whose
+	// set code is unknown to the catalog. Reported by user: both SetInfoEnricher emits a
+	// warning ("Set code 'MB1' not found") AND CatalogValidator emits an error
+	// ("No printing at MB1 #N"). One issue per row, not two, is the expected UX.
+	[Fact]
+	public async Task EnrichAsync_UnknownSetCode_WithCsvProvidedSetName_DoesNotWarn()
+	{
+		var row = new ParsedRow(new PhysicalMtgCard
+		{
+			Count = 1,
+			Printing = new Card
+			{
+				Name = "Countless Gears Renegade",
+				Set = "MB1",                 // not in catalog (redirected to PLST upstream)
+				CollectorNumber = "62",
+				SetName = "Mystery Booster", // also not in catalog
+			},
+		}, RowNumber: 1);
+
+		var issues = new List<ImportIssue>();
+		await _enricher.EnrichAsync([row], issues, CancellationToken.None);
+
+		issues.Should().BeEmpty(
+			because: "the CSV supplied both a set code and a set name; SetInfoEnricher's role is to canonicalize against the catalog, not to flag every unknown set — CatalogValidator's downstream lookup will already emit a precise (Set, CollectorNumber) error.");
+	}
+
 	[Fact]
 	public async Task EnrichAsync_AlreadyCanonicalSetName_PassesThroughUnchanged()
 	{


### PR DESCRIPTION
## Summary

User flagged: rows showing up twice in the import-issues panel — once under a Warning group, once under an Error group. Reproduces on `moxfield-collection.csv`: `SetInfoEnricher` emits *"Set code 'MB1' not found in Scryfall data"* (Warning), then `CatalogValidator` immediately drops the row with *"No printing at MB1 #62 in Scryfall data"* (Error). Both are true facts about the same row, but visually they read as redundant.

**Fix is render-only:** when a row has an Error, hide its Warnings. The Error already names the failure precisely; the precondition Warning is noise once the row is dropped.

| | |
| --- | --- |
| `MtgCsvProcessor.razor` | Build a `HashSet<int>` of row numbers with Errors. Filter `displayedIssues` = Errors + Warnings whose row isn't in that set. The grouping below uses `displayedIssues` instead of `r.Issues`. |
| Top-of-panel chips | Switched to row-based counts (distinct rows with errors / warnings) instead of issue-based. Previously a row with two issues double-counted. |
| Underlying `r.Issues` | Unchanged. Error-report CSV download + the Report-to-GitHub payload remain exhaustive on purpose — those audiences want the full enricher trail. UI is the only layer where the overlap reads as redundancy. |

Plus a small SetInfoEnricher diagnostic test (`EnrichAsync_UnknownSetCode_WithCsvProvidedSetName_DoesNotWarn`) — comes out of the diagnosis trail for this fix. Pins the existing behavior on the corner case where a CSV supplies both an unknown set code AND a CSV-provided set name (no warning fires for that combination).

## Test plan

- [x] `dotnet test MtgCsvHelper.slnx` — 175 passing
- [x] Local dev-server verification with `moxfield-collection.csv`: rows with the MB1 set-code Warning + the resulting "No printing at MB1 #N" Error now show only the Error group entry; warning chip count drops accordingly ✅
- [ ] CI green