### PR TITLE
Fail gh-pages deploy when Scryfall refresh fails (#100)

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -31,6 +31,7 @@ jobs:
       # site without `data/` and the app would 404 on card lookup — fail the
       # workflow instead of deploying a broken site.
       - name: Refresh reference card bundle
+        timeout-minutes: 10
         run: dotnet run --project tools/MtgCsvHelper.RefreshReferenceData -c Release
 
       # Publishes Blazor project to the release-folder

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -27,18 +27,11 @@ jobs:
 
       # Refresh the bundled Scryfall reference catalog so the deployed app
       # ships with up-to-date data. Output goes to wwwroot/data/cards.min.json.gz.
-      # `continue-on-error: true` keeps deploys working when Scryfall's bulk-data
-      # endpoint is degraded — the previously committed bundle is used as fallback.
+      # The bundle is gitignored, so a failure here means publish would ship a
+      # site without `data/` and the app would 404 on card lookup — fail the
+      # workflow instead of deploying a broken site.
       - name: Refresh reference card bundle
-        id: refresh-bundle
-        continue-on-error: true
         run: dotnet run --project tools/MtgCsvHelper.RefreshReferenceData -c Release
-
-      # Surface a stale-bundle deploy as a workflow warning so a green CI run
-      # doesn't hide the fact that we shipped yesterday's catalog.
-      - name: Warn on stale bundle
-        if: steps.refresh-bundle.outcome == 'failure'
-        run: echo "::warning::Reference card bundle refresh failed — deploying with the previously committed bundle (may be stale)."
 
       # Publishes Blazor project to the release-folder
       - name: Publish BlazorWebAssembly Project


### PR DESCRIPTION
## Summary

- Removes `continue-on-error: true` and the misleading "warn on stale bundle" step from `.github/workflows/github-pages.yml`.
- A Scryfall outage during deploy now fails the workflow loudly instead of silently shipping a site missing the `data/` folder.

## Why

Fixes #100. The workflow's existing comment claimed a "previously committed bundle" was used as fallback, but `MtgCsvHelper.BlazorWebAssembly/wwwroot/data/cards.min.json.gz` is gitignored — there is no fallback on a fresh CI checkout. The 1.4.0 release deploy ([run 26252972890](https://github.com/StepKie/MtgCsvHelper/actions/runs/26252972890)) hit this when Scryfall returned 503 and shipped a broken site until a manual re-run.

Per issue discussion: Option B (hard-fail). Trade-off accepted — a Scryfall outage now blocks releases until they recover, but we never ship a 404-on-load app.

## Test plan

- [ ] Workflow YAML is still well-formed (GitHub Actions parses it on the merge to `main`).
- [ ] Confirm the next release deploy (which exercises the real Scryfall fetch) still succeeds.
- [ ] Reproduction for the failure path: deliberately point the refresh tool at a 503 endpoint locally → confirm the step exits non-zero and the workflow would abort before `dotnet publish`.