### PR TITLE
Fix Dragon Shield import: Guild Kit set codes + variant foil treatments

### DIFF
--- a/MtgCsvHelper.Tests/DragonShieldCodeReadConverterTests.cs
+++ b/MtgCsvHelper.Tests/DragonShieldCodeReadConverterTests.cs
@@ -1,0 +1,20 @@
+using MtgCsvHelper.Converters;
+
+namespace MtgCsvHelper.Tests;
+
+public class DragonShieldCodeReadConverterTests
+{
+	static readonly DragonShieldCodeReadConverter Converter = new();
+
+	// The Guild Kit branch returns before dereferencing row/memberMapData; passthrough is covered end-to-end.
+	static object? Convert(string text) => Converter.ConvertFromString(text, null!, null!);
+
+	[Theory]
+	[InlineData("GK1_DIMIR", "GK1")]
+	[InlineData("GK2_AZORIU", "GK2")]
+	[InlineData("GK2_RAKDOS", "GK2")]
+	[InlineData("GK2_ORZHOV", "GK2")]
+	[InlineData("gk2_simic", "GK2")]
+	public void GuildKitCodes_CollapseToScryfallSetCode(string dragonShieldCode, string expected) =>
+		Convert(dragonShieldCode).Should().Be(expected);
+}

--- a/MtgCsvHelper.Tests/FaultToleranceTests.cs
+++ b/MtgCsvHelper.Tests/FaultToleranceTests.cs
@@ -110,7 +110,6 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 	[Fact]
 	public void DragonShieldGuildKitCode_ResolvesToScryfallSet()
 	{
-		// Dragon Shield's per-guild codes collapse to one Scryfall set: GK2_AZORIU #2 is gk2 #2 (Azorius Herald).
 		var csv = "\"sep=,\"\n"
 			+ "Folder Name,Quantity,Trade Quantity,Card Name,Set Code,Set Name,Card Number,Condition,Printing,Language,Price Bought,Date Bought\n"
 			+ "Test,1,0,Azorius Herald,GK2_AZORIU,Guild Kit: Azorius,2,NearMint,Normal,English,0.00,2026-05-15\n";

--- a/MtgCsvHelper.Tests/FaultToleranceTests.cs
+++ b/MtgCsvHelper.Tests/FaultToleranceTests.cs
@@ -108,6 +108,22 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 	}
 
 	[Fact]
+	public void DragonShieldGuildKitCode_ResolvesToScryfallSet()
+	{
+		// Dragon Shield's per-guild codes map to one Scryfall set sharing collector numbers:
+		// GK2_AZORIU #2 is the same printing as gk2 #2 (Azorius Herald).
+		var csv = "\"sep=,\"\n"
+			+ "Folder Name,Quantity,Trade Quantity,Card Name,Set Code,Set Name,Card Number,Condition,Printing,Language,Price Bought,Date Bought\n"
+			+ "Test,1,0,Azorius Herald,GK2_AZORIU,Guild Kit: Azorius,2,NearMint,Normal,English,0.00,2026-05-15\n";
+
+		var result = Handler("DRAGONSHIELD").ParseCollectionCsv(CsvStream(csv));
+
+		result.Issues.Should().NotContain(i => i.Severity == IssueSeverity.Error);
+		result.Collection.Cards.Should().ContainSingle()
+			.Which.Printing.Set.Should().Be("GK2");
+	}
+
+	[Fact]
 	public void BlankAndDelimiterOnlyRows_SkippedSilently()
 	{
 		var csv = MoxHeader + "\n"

--- a/MtgCsvHelper.Tests/FaultToleranceTests.cs
+++ b/MtgCsvHelper.Tests/FaultToleranceTests.cs
@@ -110,8 +110,7 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 	[Fact]
 	public void DragonShieldGuildKitCode_ResolvesToScryfallSet()
 	{
-		// Dragon Shield's per-guild codes map to one Scryfall set sharing collector numbers:
-		// GK2_AZORIU #2 is the same printing as gk2 #2 (Azorius Herald).
+		// Dragon Shield's per-guild codes collapse to one Scryfall set: GK2_AZORIU #2 is gk2 #2 (Azorius Herald).
 		var csv = "\"sep=,\"\n"
 			+ "Folder Name,Quantity,Trade Quantity,Card Name,Set Code,Set Name,Card Number,Condition,Printing,Language,Price Bought,Date Bought\n"
 			+ "Test,1,0,Azorius Herald,GK2_AZORIU,Guild Kit: Azorius,2,NearMint,Normal,English,0.00,2026-05-15\n";

--- a/MtgCsvHelper.Tests/FinishConverterTests.cs
+++ b/MtgCsvHelper.Tests/FinishConverterTests.cs
@@ -1,0 +1,31 @@
+using MtgCsvHelper.Converters;
+
+namespace MtgCsvHelper.Tests;
+
+public class FinishConverterTests
+{
+	// DragonShield's "Printing" column: Normal / Foil plus an open-ended set of variant treatments.
+	static readonly FinishConverter Converter = new(new FinishConfiguration("Printing", Foil: "Foil", Normal: "Normal", Etched: null));
+
+	// The accept/normal branches never touch row or memberMapData; only the throw path does.
+	static object? Convert(string text) => Converter.ConvertFromString(text, null!, null!);
+
+	[Theory]
+	[InlineData("Foil")]
+	[InlineData("Surge Foil")]
+	[InlineData("Step and Compleat Foil")]
+	[InlineData("Rainbow Foil")]
+	[InlineData("Double Rainbow Foil")]
+	[InlineData("Gilded Foil")]
+	[InlineData("Galaxy Foil")]
+	[InlineData("surge foil")]
+	public void VariantFoilTreatments_MapToFoil(string printing) =>
+		Convert(printing).Should().Be(true);
+
+	[Theory]
+	[InlineData("Normal")]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void NonFoilTreatments_MapToNonFoil(string printing) =>
+		Convert(printing).Should().Be(false);
+}

--- a/MtgCsvHelper/CardMapFactory.cs
+++ b/MtgCsvHelper/CardMapFactory.cs
@@ -41,6 +41,7 @@ public class CardMapFactory(IConfiguration config, IReferenceCardCatalog catalog
 			throw new InvalidOperationException($"Format '{format}' is write-only and cannot be parsed.");
 		}
 		if (format.Equals("DECKBOX", StringComparison.OrdinalIgnoreCase)) { return new DeckboxMap(cfg, catalog); }
+		if (format.Equals("DRAGONSHIELD", StringComparison.OrdinalIgnoreCase)) { return new DragonShieldMap(cfg, catalog); }
 		return new PhysicalCardMap(cfg, catalog);
 	}
 
@@ -53,6 +54,7 @@ public class CardMapFactory(IConfiguration config, IReferenceCardCatalog catalog
 		}
 		if (format.Equals("CARDKINGDOM", StringComparison.OrdinalIgnoreCase)) { return new CardKingdomWriteMap(cfg, catalog); }
 		if (format.Equals("DECKBOX", StringComparison.OrdinalIgnoreCase)) { return new DeckboxMap(cfg, catalog); }
+		if (format.Equals("DRAGONSHIELD", StringComparison.OrdinalIgnoreCase)) { return new DragonShieldMap(cfg, catalog); }
 		return new PhysicalCardMap(cfg, catalog);
 	}
 

--- a/MtgCsvHelper/Converters/DragonShieldCodeReadConverter.cs
+++ b/MtgCsvHelper/Converters/DragonShieldCodeReadConverter.cs
@@ -3,11 +3,7 @@ using CsvHelper.TypeConversion;
 
 namespace MtgCsvHelper.Converters;
 
-/// <summary>
-/// On read from a Dragon Shield CSV, collapses its Ravnica Guild Kit set codes (GK1_DIMIR,
-/// GK2_AZORIU, …) to the canonical Scryfall code (GK1/GK2); the guild suffix is cosmetic and
-/// collector numbers are shared across the kit. All other codes pass through to UpperCaseConverter.
-/// </summary>
+/// <summary>On read from a Dragon Shield CSV, collapses GK1_*/GK2_* guild-kit codes to the canonical Scryfall code (GK1/GK2); all other codes pass through to UpperCaseConverter.</summary>
 internal sealed class DragonShieldCodeReadConverter : UpperCaseConverter
 {
 	public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)

--- a/MtgCsvHelper/Converters/DragonShieldCodeReadConverter.cs
+++ b/MtgCsvHelper/Converters/DragonShieldCodeReadConverter.cs
@@ -1,0 +1,23 @@
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
+
+namespace MtgCsvHelper.Converters;
+
+/// <summary>
+/// On read from a Dragon Shield CSV, collapses its Ravnica Guild Kit set codes (GK1_DIMIR,
+/// GK2_AZORIU, …) to the canonical Scryfall code (GK1/GK2); the guild suffix is cosmetic and
+/// collector numbers are shared across the kit. All other codes pass through to UpperCaseConverter.
+/// </summary>
+internal sealed class DragonShieldCodeReadConverter : UpperCaseConverter
+{
+	public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
+	{
+		if (text is not null
+			&& (text.StartsWith("GK1_", StringComparison.OrdinalIgnoreCase) || text.StartsWith("GK2_", StringComparison.OrdinalIgnoreCase)))
+		{
+			return text[..3].ToUpperInvariant();
+		}
+
+		return base.ConvertFromString(text, row, memberMapData);
+	}
+}

--- a/MtgCsvHelper/Converters/FinishConverter.cs
+++ b/MtgCsvHelper/Converters/FinishConverter.cs
@@ -7,13 +7,6 @@ public class FinishConverter(FinishConfiguration configuration) : ITypeConverter
 {
 	readonly FinishConfiguration _finishConfig = configuration;
 
-	// DragonShield-specific variant foil treatments. Hardcoded here because no other format
-	// in the repo emits these strings; widening this list silently re-routes other formats'
-	// values, so per-format config aliases are the right long-term fix (tracked as a follow-up
-	// to the tri-state Foil enum below).
-	static readonly HashSet<string> FoilVariants = new(StringComparer.OrdinalIgnoreCase)
-		{ "Rainbow Foil", "Double Rainbow Foil", "Gilded Foil" };
-
 	public object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
 	{
 		if (string.IsNullOrWhiteSpace(text)) { return false; }
@@ -22,7 +15,8 @@ public class FinishConverter(FinishConfiguration configuration) : ITypeConverter
 		// Tri-state Foil enum is the planned follow-up; see ConvertToString for the matching write-side data loss.
 		if (text.MatchesConfig(_finishConfig.Etched)) { return true; }
 		if (text.MatchesConfig(_finishConfig.Normal)) { return false; }
-		if (FoilVariants.Contains(text)) { return true; }
+		// Variant treatments (Surge Foil, Step and Compleat Foil, …) all carry the word "Foil".
+		if (text.Contains("foil", StringComparison.OrdinalIgnoreCase)) { return true; }
 
 		throw new TypeConverterException(this, memberMapData, text, row.Context, $"Unrecognized Foil value '{text}'");
 	}

--- a/MtgCsvHelper/Maps/DragonShieldMap.cs
+++ b/MtgCsvHelper/Maps/DragonShieldMap.cs
@@ -1,0 +1,12 @@
+using MtgCsvHelper.Converters;
+
+namespace MtgCsvHelper.Maps;
+
+/// <summary>PhysicalCardMap with a Dragon Shield Set-code converter that resolves its proprietary Ravnica Guild Kit codes (GK1_*, GK2_*) to canonical Scryfall codes.</summary>
+public sealed class DragonShieldMap : PhysicalCardMap
+{
+	public DragonShieldMap(FormatConfig cfg, IReferenceCardCatalog catalog)
+		: base(cfg, catalog, new DragonShieldCodeReadConverter())
+	{
+	}
+}

--- a/MtgCsvHelper/Maps/PhysicalCardMap.cs
+++ b/MtgCsvHelper/Maps/PhysicalCardMap.cs
@@ -10,7 +10,7 @@ namespace MtgCsvHelper.Maps;
 // so the body reads as a flat list of mappings rather than a forest of null checks.
 public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 {
-	public PhysicalCardMap(FormatConfig cfg, IReferenceCardCatalog catalog)
+	public PhysicalCardMap(FormatConfig cfg, IReferenceCardCatalog catalog, ITypeConverter? setCodeConverter = null)
 	{
 		// Explicit indices override CsvHelper's clustering of nested-member maps
 		// (Printing.Name, Printing.Set, …) — registration order alone interleaves
@@ -39,7 +39,7 @@ public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 		// At least one of SetCode / SetName is expected per format (sites differ on which they include).
 		// CollectorNumberConverter is applied universally (not MTGO-specific) — it's a no-op for any
 		// collector number without a "/", and "/" doesn't appear in Scryfall data.
-		MapOptional(c => c.Printing.Set, cfg.SetCode)?.TypeConverter<UpperCaseConverter>().Index(4);
+		MapOptional(c => c.Printing.Set, cfg.SetCode)?.TypeConverter(setCodeConverter ?? new UpperCaseConverter()).Index(4);
 		MapOptional(c => c.Printing.SetName, cfg.SetName)?.Index(5);
 		MapOptional(c => c.Printing.CollectorNumber, cfg.SetNumber)?.TypeConverter<CollectorNumberConverter>().Index(6);
 

--- a/MtgCsvHelper/Resources/SampleCsvs/Tests/SITE_BEHAVIOR.md
+++ b/MtgCsvHelper/Resources/SampleCsvs/Tests/SITE_BEHAVIOR.md
@@ -99,12 +99,14 @@ So DragonShield's `ShortNames: true` config setting only applies to a subset of 
 
 **Normalizes:**
 - **The List entries get demangled** to original printings. We submitted `Demonic Tutor PLST DDC-49` → re-exported as `Demonic Tutor DVD #49` (Duel Decks: Divine vs. Demonic). Submitted `Recruiter of the Guard PLST CN2-22` → re-exported as `Recruiter of the Guard CN2 #22` (Conspiracy: Take the Crown). DragonShield treats PLST as a redirection and unwinds it.
-- **Variant foil treatments**: DragonShield's Printing column emits more than 3 values. Observed: `Normal`, `Foil`, `Etched`, `Rainbow Foil`, `Double Rainbow Foil`, `Gilded Foil`. Our model collapses them all to `bool? Foil` (true for any foil-like; false for normal). Hardcoded fallback in `FinishConverter` keeps the parser from rejecting these strings. Follow-up: config-level aliases per format, and possibly tri-state finish in the model.
+- **Variant foil treatments**: DragonShield's Printing column emits an open-ended set of values beyond the basic 3. Observed: `Normal`, `Foil`, `Etched`, `Rainbow Foil`, `Double Rainbow Foil`, `Gilded Foil`, `Surge Foil`, `Step and Compleat Foil`. New treatments keep appearing as WotC invents them, so `FinishConverter` matches any value containing the word `foil` (case-insensitive) rather than an allowlist that goes stale (#102). Our model still collapses every foil-like value to `bool? Foil` (true for any foil; false for normal). Follow-up: possibly tri-state finish in the model.
+- **Ravnica Guild Kit set codes**: DragonShield emits proprietary per-guild codes — `GK1_<GUILD>` (Guilds of Ravnica, e.g. `GK1_DIMIR`) and `GK2_<GUILD>` (Ravnica Allegiance, e.g. `GK2_AZORIU`, `GK2_ORZHOV`, `GK2_SIMIC`, `GK2_GRUUL`, `GK2_RAKDOS`). The guild suffix is cosmetic (truncated to ≤6 chars: `azorius` → `AZORIU`) and the collector numbers are shared across the kit, so the Scryfall set is a single `gk1`/`gk2` (`GK2_AZORIU #2` == `gk2 #2`, Azorius Herald). `DragonShieldCodeReadConverter` collapses `GK[12]_*` to `gk1`/`gk2` on read (#102).
 - **Resets `Price Bought` to `0.00`** on Moxfield-format import.
 
-**Rejects:**
+**Rejects (on *our* import of DragonShield exports):**
 - **Minimum-info imports** with blank `Card Name` + `Set Name` (just `Set Code` + `Card Number`) are rejected. DragonShield requires the name fields to be populated; it doesn't deduce the card from `(Set Code, Card Number)` alone like Moxfield's fuzzy matcher does.
 - Diverging synthetic drafts fail silently with a generic "please check structure" message — DragonShield doesn't report specific row errors on native import. Round-tripping through Moxfield-format import gives more diagnostics (errors are listed per row).
+- **Regional / foreign-language set codes** like `LEGI` (Legends Italian) don't map to a Scryfall code and fail catalog validation (row dropped). Foreign-language card names also fail name-matching against our English-only catalog. Tracked in #103.
 
 **Moxfield-format importer in DragonShield is buggy:**
 The cross-format import path that worked has gaps. Observed mapping behavior from Moxfield → DragonShield:
@@ -119,6 +121,17 @@ The cross-format import path that worked has gaps. Observed mapping behavior fro
 | `Damaged` | `Poor` | **DROPPED** (row ignored) |
 
 So DragonShield's Moxfield-importer maps only 4 of Moxfield's 6 conditions, with at least one wrong middle mapping. Our DragonShield reference-collection therefore has only 4 of DS's 7 condition values represented (NearMint, Good, Played, Poor). The other 3 (Mint, Excellent, LightPlayed) would need manual UI entry to cover.
+
+**Set codes are ignored on CSV import — name-matching wins (export round-trip):**
+When *we* export to DragonShield, its CSV importer does **not** use the `Set Code` / `Card Number` columns to pick a printing — it matches by `Card Name` and falls back to its own default printing. Feeding canonical Scryfall codes (`gk2`) silently mis-resolves reprints to the wrong edition, with no error shown. DragonShield's own **native** `GK<n>_<GUILD>` codes *are* honored. Confirmed by round-tripping 8 Guild Kit cards (#104):
+
+| Card | We exported (canonical) → DS stored | We exported (native) → DS stored |
+|---|---|---|
+| Azorius Herald | `GK2` #2 → Commander 2013 #6 ✗ | `GK2_AZORIU` #2 → Guild Kit: Azorius #2 ✓ |
+| Belfry Spirit | `GK2` #29 → Guildpact #2 ✗ | `GK2_ORZHOV` #29 → Guild Kit: Orzhov #29 ✓ |
+| Cloudfin Raptor | `GK2` #108 → Gatecrash #32 ✗ | `GK2_SIMIC` #108 → Guild Kit: Simic #108 ✓ |
+
+Only single-printing names (e.g. Etrata, the Silencer — exists only in the GRN kit) resolve correctly under canonical codes. Implication for our DragonShield **writer**: to round-trip guild-kit cards we'd need to emit native `GK<n>_<GUILD>` codes (the guild is recoverable from Scryfall's `watermark` field). Tracked in #104.
 
 ---
 


### PR DESCRIPTION
Fixes the bulk of the Dragon Shield import errors reported in #102, in two independent commits.

## 1. Accept all variant foil treatments

`FinishConverter` only accepted an enumerated allowlist of Dragon Shield variant foils (Rainbow Foil, Double Rainbow Foil, Gilded Foil), so newer treatments (Surge Foil, Step and Compleat Foil, …) threw and dropped the row. Now matches any value containing "foil" — Dragon Shield labels every variant with the word, a non-foil printing wrongly mapped is still caught by the catalog validator, and no other format's normal value contains "foil".

## 2. Resolve Ravnica Guild Kit set codes

Dragon Shield emits per-guild codes (`GK1_DIMIR`, `GK2_AZORIU`, …) for the Ravnica guild kits, but the Scryfall set is a single `gk1`/`gk2` sharing collector numbers across guilds — so those codes never resolved and the rows were dropped (the largest error cluster in #102). A new `DragonShieldCodeReadConverter` collapses `GK[12]_*` to the canonical `gk1`/`gk2` (the guild suffix is cosmetic; collector numbers are unchanged).

Injected through a new optional `setCodeConverter` parameter on `PhysicalCardMap` rather than the reflection-based member-map swap `DeckboxMap` uses. Write side stays identity (emits the canonical code), matching the Deckbox precedent.

## Tests

+6: a `FinishConverter` theory for the variant foils, a `DragonShieldCodeReadConverter` theory for the guild-kit rule, and an end-to-end `FaultToleranceTests` case proving `GK2_AZORIU #2` resolves to Azorius Herald through the real catalog. Full suite green (196).

## Follow-ups (out of scope here)

- #103 — foreign-language imports (Italian card names, `LEGI` regional set code) — the remaining ~12 of 157 errors in #102.
- #104 — Dragon Shield **export** direction: it ignores canonical codes on re-import, so guild-kit cards exported back to Dragon Shield need native `GK<n>_<GUILD>` codes.
