### PR TITLE
Embed import-error data in the Report-to-GitHub issue body

### DIFF
--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -150,7 +150,7 @@
 			           StartIcon="@Icons.Material.Filled.ReportProblem" OnClick="DownloadErrorCsv">
 				Error report
 			</MudButton>
-			<MudTooltip Text="Downloads the error CSV and opens a pre-filled GitHub issue. Drag the downloaded file into the issue to attach.">
+			<MudTooltip Text="Opens a pre-filled GitHub issue with the error details included inline. For very large reports, also attach the downloaded CSV.">
 				<MudButton Variant="Variant.Outlined" Color="Color.Default"
 				           StartIcon="@Icons.Custom.Brands.GitHub" OnClick="ReportErrorsOnGitHub">
 					Report to GitHub
@@ -595,58 +595,24 @@
 		var errors = _result.Issues.Where(i => i.Severity == IssueSeverity.Error).ToList();
 		if (errors.Count == 0) return;
 
-		var sb = new StringBuilder();
-		sb.AppendLine("RowNumber,RawContent,Reason");
-		foreach (var e in errors)
-		{
-			sb.AppendLine($"{e.RowNumber},{Csv(e.RawContent)},{Csv(e.Reason)}");
-		}
-
-		var bytes = Encoding.UTF8.GetBytes(sb.ToString());
+		var bytes = Encoding.UTF8.GetBytes(ImportErrorReport.BuildCsv(errors));
 		using var stream = new MemoryStream(bytes);
 		using var streamRef = new DotNetStreamReference(stream, leaveOpen: false);
 		await JS.InvokeVoidAsync("downloadFileFromStream", $"{_result.InputFormat}-import-errors-{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv", streamRef);
-
-		static string Csv(string? value) => value is null ? "" : $"\"{value.Replace("\"", "\"\"")}\"";
 	}
 
 	async Task ReportErrorsOnGitHub()
 	{
 		if (_result is null) return;
-		var errors = _result.Issues.Where(i => i.Severity == IssueSeverity.Error).ToList();
-		if (errors.Count == 0) return;
+		if (!_result.Issues.Any(i => i.Severity == IssueSeverity.Error)) return;
 
-		// Download the error CSV so the user can drag it into the issue.
-		await DownloadErrorCsv();
+		var report = ImportErrorReport.Build(
+			_result.InputFormat, _result.OutputFormat, _result.ImportedAt, _result.Summary.UniqueCount, _result.Issues);
 
-		// Top 5 distinct error reasons by frequency, for an at-a-glance summary in the body.
-		var topReasons = errors
-			.GroupBy(e => e.Reason)
-			.OrderByDescending(g => g.Count())
-			.Take(5)
-			.Select(g => $"- {g.Count()}× {g.Key}");
+		// A downloaded file to attach is only needed when the inline data didn't all fit.
+		if (report.Trimmed) { await DownloadErrorCsv(); }
 
-		var warningCount = _result.Issues.Count(i => i.Severity == IssueSeverity.Warning);
-		var body = $"## Import errors\n\n" +
-			$"- **Input format**: {_result.InputFormat}\n" +
-			$"- **Output format**: {_result.OutputFormat}\n" +
-			$"- **When**: {_result.ImportedAt:yyyy-MM-dd HH:mm}\n" +
-			$"- **Rows imported successfully**: {_result.Summary.UniqueCount}\n" +
-			$"- **Errors (rows skipped)**: {errors.Count}\n" +
-			$"- **Warnings (imported with notes)**: {warningCount}\n\n" +
-			$"### Top error reasons\n\n{string.Join("\n", topReasons)}\n\n" +
-			$"### Attached CSV\n\n" +
-			$"Please drag the just-downloaded `{_result.InputFormat}-import-errors-*.csv` file into this issue to attach the full error data.\n\n" +
-			$"### Additional context\n\n" +
-			$"_Describe what you were trying to do — which source CSV, anything unusual about the data._\n";
-
-		var title = $"Import errors: {FormatDisplay.For(_result.InputFormat)} → {FormatDisplay.For(_result.OutputFormat)}";
-		var url = $"https://github.com/StepKie/MtgCsvHelper/issues/new"
-			+ $"?title={Uri.EscapeDataString(title)}"
-			+ $"&labels={Uri.EscapeDataString("bug,import-error")}"
-			+ $"&body={Uri.EscapeDataString(body)}";
-
-		await JS.InvokeVoidAsync("open", url, "_blank", "noopener,noreferrer");
+		await JS.InvokeVoidAsync("open", report.IssueUrl, "_blank", "noopener,noreferrer");
 	}
 
 	public void Dispose()

--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -609,7 +609,6 @@
 		var report = ImportErrorReport.Build(
 			_result.InputFormat, _result.OutputFormat, _result.ImportedAt, _result.Summary.UniqueCount, _result.Issues);
 
-		// A downloaded file to attach is only needed when the inline data didn't all fit.
 		if (report.Trimmed) { await DownloadErrorCsv(); }
 
 		await JS.InvokeVoidAsync("open", report.IssueUrl, "_blank", "noopener,noreferrer");

--- a/MtgCsvHelper.Tests/ImportErrorReportTests.cs
+++ b/MtgCsvHelper.Tests/ImportErrorReportTests.cs
@@ -85,7 +85,7 @@ public class ImportErrorReportTests
 		var body = BodyOf(report);
 
 		report.Trimmed.Should().BeTrue();
-		(report.IssueUrl.Length <= maxUrl).Should().BeTrue("the prefilled URL must stay under GitHub's length cap");
+		report.IssueUrl.Length.Should().BeLessThanOrEqualTo(maxUrl, "the prefilled URL must stay under GitHub's length cap");
 		body.Should().Contain("was downloaded"); // attach-fallback note present when trimmed
 		body.Should().Contain("### Error reasons"); // the histogram always survives trimming
 	}

--- a/MtgCsvHelper.Tests/ImportErrorReportTests.cs
+++ b/MtgCsvHelper.Tests/ImportErrorReportTests.cs
@@ -7,7 +7,13 @@ public class ImportErrorReportTests
 	static ImportIssue Error(int row, string reason, string raw) =>
 		new(IssueSeverity.Error, row, reason, RawContent: raw);
 
-	static string BodyOf((string IssueUrl, bool Trimmed) report) => Uri.UnescapeDataString(report.IssueUrl);
+	// Extract just the body= query parameter (the last one) so assertions can't pass on title text.
+	static string BodyOf((string IssueUrl, bool Trimmed) report)
+	{
+		const string marker = "&body=";
+		var start = report.IssueUrl.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+		return Uri.UnescapeDataString(report.IssueUrl[start..]);
+	}
 
 	[Fact]
 	public void ReasonHistogram_NormalizesCollectorNumbers_SoSameSetAggregates()

--- a/MtgCsvHelper.Tests/ImportErrorReportTests.cs
+++ b/MtgCsvHelper.Tests/ImportErrorReportTests.cs
@@ -34,14 +34,16 @@ public class ImportErrorReportTests
 	[Fact]
 	public void ReasonHistogram_CapsAtMaxReasons_WithOverflowLine()
 	{
-		var errors = Enumerable.Range(0, 25)
+		const int distinctReasons = 25;
+		const int maxReasons = 20;
+		var errors = Enumerable.Range(0, distinctReasons)
 			.Select(i => Error(i, $"Invalid value 'V{i}' for column 'Foil'", "x"))
 			.ToList();
 
-		var histogram = ImportErrorReport.ReasonHistogram(errors, maxReasons: 20);
+		var histogram = ImportErrorReport.ReasonHistogram(errors, maxReasons);
 
-		histogram.Should().Contain("… and 5 more distinct reasons");
-		histogram.Split('\n').Should().HaveCount(21); // 20 reasons + overflow line
+		histogram.Should().Contain($"… and {distinctReasons - maxReasons} more distinct reasons");
+		histogram.Split('\n').Should().HaveCount(maxReasons + 1);
 	}
 
 	[Fact]

--- a/MtgCsvHelper.Tests/ImportErrorReportTests.cs
+++ b/MtgCsvHelper.Tests/ImportErrorReportTests.cs
@@ -1,0 +1,93 @@
+namespace MtgCsvHelper.Tests;
+
+public class ImportErrorReportTests
+{
+	static readonly DateTime When = new(2026, 5, 31, 12, 0, 0);
+
+	static ImportIssue Error(int row, string reason, string raw) =>
+		new(IssueSeverity.Error, row, reason, RawContent: raw);
+
+	static string BodyOf((string IssueUrl, bool Trimmed) report) => Uri.UnescapeDataString(report.IssueUrl);
+
+	[Fact]
+	public void ReasonHistogram_NormalizesCollectorNumbers_SoSameSetAggregates()
+	{
+		var errors = new[]
+		{
+			Error(1, "No printing at GK2_AZORIU #2 in Scryfall data", "x"),
+			Error(2, "No printing at GK2_AZORIU #3 in Scryfall data", "x"),
+			Error(3, "Invalid value 'Surge Foil' for column 'Foil'", "x"),
+		};
+
+		var histogram = ImportErrorReport.ReasonHistogram(errors, maxReasons: 20);
+
+		histogram.Should().Contain("2× No printing at GK2_AZORIU #N in Scryfall data");
+		histogram.Should().Contain("1× Invalid value 'Surge Foil' for column 'Foil'");
+	}
+
+	[Fact]
+	public void ReasonHistogram_CapsAtMaxReasons_WithOverflowLine()
+	{
+		var errors = Enumerable.Range(0, 25)
+			.Select(i => Error(i, $"Invalid value 'V{i}' for column 'Foil'", "x"))
+			.ToList();
+
+		var histogram = ImportErrorReport.ReasonHistogram(errors, maxReasons: 20);
+
+		histogram.Should().Contain("… and 5 more distinct reasons");
+		histogram.Split('\n').Should().HaveCount(21); // 20 reasons + overflow line
+	}
+
+	[Fact]
+	public void Build_SmallReport_EmbedsEveryRowInline_AndIsNotTrimmed()
+	{
+		var errors = new[] { Error(1, "No printing at M11 #9999 in Scryfall data", "1,Lightning Bolt,M11,9999") };
+
+		var report = ImportErrorReport.Build("DRAGONSHIELD", "MOXFIELD", When, importedRows: 10, errors);
+		var body = BodyOf(report);
+
+		report.Trimmed.Should().BeFalse();
+		body.Should().Contain("## Import errors");
+		body.Should().Contain("- **Input format**: DRAGONSHIELD");
+		body.Should().Contain("- **Errors (rows skipped)**: 1");
+		body.Should().Contain("```csv");
+		body.Should().Contain("1,Lightning Bolt,M11,9999");
+		body.Should().NotContain("was downloaded"); // no attach-fallback note when nothing was trimmed
+	}
+
+	[Fact]
+	public void Build_TitleUsesFriendlyFormatNames()
+	{
+		var report = ImportErrorReport.Build("DRAGONSHIELD", "MOXFIELD", When, 1,
+			[Error(1, "No printing at M11 #9999 in Scryfall data", "x")]);
+
+		report.IssueUrl.Should().Contain(Uri.EscapeDataString("Import errors: Dragon Shield → Moxfield"));
+	}
+
+	[Fact]
+	public void Build_LargeReport_TrimsRows_FlagsTruncation_AndStaysUnderUrlCap()
+	{
+		const int maxUrl = 7500;
+		var errors = Enumerable.Range(0, 500)
+			.Select(i => Error(i, $"No printing at SET{i} #{i} in Scryfall data",
+				$"{i},Some Reasonably Long Card Name Number {i},SET{i},{i}"))
+			.ToList();
+
+		var report = ImportErrorReport.Build("DRAGONSHIELD", "MOXFIELD", When, 0, errors, maxUrlLength: maxUrl);
+		var body = BodyOf(report);
+
+		report.Trimmed.Should().BeTrue();
+		(report.IssueUrl.Length <= maxUrl).Should().BeTrue("the prefilled URL must stay under GitHub's length cap");
+		body.Should().Contain("was downloaded"); // attach-fallback note present when trimmed
+		body.Should().Contain("### Error reasons"); // the histogram always survives trimming
+	}
+
+	[Fact]
+	public void BuildCsv_HasHeader_AndQuotesEmbeddedCommasAndQuotes()
+	{
+		var csv = ImportErrorReport.BuildCsv([Error(5, "Reason with \"quotes\"", "5,\"Name, with comma\",SET,5")]);
+
+		csv.Should().StartWith("RowNumber,RawContent,Reason");
+		csv.Should().Contain("\"\"quotes\"\""); // inner quotes doubled
+	}
+}

--- a/MtgCsvHelper/ImportErrorReport.cs
+++ b/MtgCsvHelper/ImportErrorReport.cs
@@ -86,7 +86,6 @@ public static class ImportErrorReport
 			+ $"&body={Uri.EscapeDataString(body)}";
 	}
 
-	// Fenced CSV block of the error rows, plus an attach-the-download note when not all rows fit.
 	static string ErrorDataBlock(string header, IReadOnlyList<string> rows, int rowCount, string inputFormat)
 	{
 		var block = $"### Error data\n\n```csv\n{header}\n{string.Join("\n", rows.Take(rowCount))}\n```\n";

--- a/MtgCsvHelper/ImportErrorReport.cs
+++ b/MtgCsvHelper/ImportErrorReport.cs
@@ -47,12 +47,16 @@ public static class ImportErrorReport
 		var header = csv[0];
 		var rows = csv.Skip(1).ToList();
 
-		// Embed every row, then drop from the end until the URL fits. The summary and reason
-		// histogram always fit, so the worst case is zero embedded rows.
-		var shown = rows.Count;
-		while (shown > 0 && Url(Compose(shown)).Length > maxUrlLength) { shown--; }
+		// Largest row count whose URL still fits the cap (URL length is monotonic in row count).
+		var lo = 0;
+		var hi = rows.Count;
+		while (lo < hi)
+		{
+			var mid = (lo + hi + 1) / 2;
+			if (Url(Compose(mid)).Length <= maxUrlLength) { lo = mid; } else { hi = mid - 1; }
+		}
 
-		return (Url(Compose(shown)), Trimmed: shown < rows.Count);
+		return (Url(Compose(lo)), Trimmed: lo < rows.Count);
 
 		string Compose(int rowCount) => string.Join("\n", new[]
 		{
@@ -94,8 +98,7 @@ public static class ImportErrorReport
 		return block;
 	}
 
-	// Distinct error causes, most frequent first. Per-row collector numbers (#2, #3, …) are
-	// normalized to "#N" so repeats of the same set/value collapse into one line.
+	// Error causes most-frequent-first, with per-row collector numbers (#2, #3, …) normalized to "#N" so the same set/value aggregates.
 	internal static string ReasonHistogram(IReadOnlyList<ImportIssue> errors, int maxReasons)
 	{
 		var groups = errors

--- a/MtgCsvHelper/ImportErrorReport.cs
+++ b/MtgCsvHelper/ImportErrorReport.cs
@@ -1,0 +1,112 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using MtgCsvHelper.Models;
+
+namespace MtgCsvHelper;
+
+/// <summary>
+/// Builds the pre-filled GitHub "new issue" URL for an import that produced errors. The error data
+/// is embedded inline — a reason histogram plus the raw rows — so the reporter doesn't have to
+/// attach a file. Rows are dropped from the end until the URL fits under GitHub's length cap; when
+/// that happens <c>Trimmed</c> is true and the caller should also offer the full CSV download.
+/// </summary>
+public static class ImportErrorReport
+{
+	const int DefaultMaxUrlLength = 7500;
+	const int DefaultMaxReasons = 20;
+
+	/// <summary>The error rows as a CSV — also offered to the user as a downloadable attachment.</summary>
+	public static string BuildCsv(IReadOnlyList<ImportIssue> errors)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine("RowNumber,RawContent,Reason");
+		foreach (var e in errors)
+		{
+			sb.AppendLine($"{e.RowNumber},{Csv(e.RawContent)},{Csv(e.Reason)}");
+		}
+
+		return sb.ToString();
+
+		static string Csv(string? value) => value is null ? "" : $"\"{value.Replace("\"", "\"\"")}\"";
+	}
+
+	public static (string IssueUrl, bool Trimmed) Build(
+		string inputFormat,
+		string outputFormat,
+		DateTime importedAt,
+		int importedRows,
+		IReadOnlyList<ImportIssue> issues,
+		int maxUrlLength = DefaultMaxUrlLength,
+		int maxReasons = DefaultMaxReasons)
+	{
+		var errors = issues.Where(i => i.Severity == IssueSeverity.Error).ToList();
+		var warningCount = issues.Count(i => i.Severity == IssueSeverity.Warning);
+		var reasons = ReasonHistogram(errors, maxReasons);
+
+		var csv = BuildCsv(errors).Replace("\r", "").TrimEnd('\n').Split('\n');
+		var header = csv[0];
+		var rows = csv.Skip(1).ToList();
+
+		// Embed every row, then drop from the end until the URL fits. The summary and reason
+		// histogram always fit, so the worst case is zero embedded rows.
+		var shown = rows.Count;
+		while (shown > 0 && Url(Compose(shown)).Length > maxUrlLength) { shown--; }
+
+		return (Url(Compose(shown)), Trimmed: shown < rows.Count);
+
+		string Compose(int rowCount) => string.Join("\n", new[]
+		{
+			"## Import errors",
+			"",
+			$"- **Input format**: {inputFormat}",
+			$"- **Output format**: {outputFormat}",
+			$"- **When**: {importedAt:yyyy-MM-dd HH:mm}",
+			$"- **Rows imported successfully**: {importedRows}",
+			$"- **Errors (rows skipped)**: {errors.Count}",
+			$"- **Warnings (imported with notes)**: {warningCount}",
+			"",
+			"### Error reasons",
+			"",
+			reasons,
+			"",
+			ErrorDataBlock(header, rows, rowCount, inputFormat),
+			"### Additional context",
+			"",
+			"_Describe what you were trying to do — which source CSV, anything unusual about the data._",
+		});
+
+		string Url(string body) =>
+			"https://github.com/StepKie/MtgCsvHelper/issues/new"
+			+ $"?title={Uri.EscapeDataString($"Import errors: {FormatDisplay.For(inputFormat)} → {FormatDisplay.For(outputFormat)}")}"
+			+ $"&labels={Uri.EscapeDataString("bug,import-error")}"
+			+ $"&body={Uri.EscapeDataString(body)}";
+	}
+
+	// Fenced CSV block of the error rows, plus an attach-the-download note when not all rows fit.
+	static string ErrorDataBlock(string header, IReadOnlyList<string> rows, int rowCount, string inputFormat)
+	{
+		var block = $"### Error data\n\n```csv\n{header}\n{string.Join("\n", rows.Take(rowCount))}\n```\n";
+		if (rowCount < rows.Count)
+		{
+			block += $"\n_Showing {rowCount} of {rows.Count} rows. The full `{inputFormat}-import-errors-*.csv` was downloaded — please drag it into this issue for the complete data._\n";
+		}
+
+		return block;
+	}
+
+	// Distinct error causes, most frequent first. Per-row collector numbers (#2, #3, …) are
+	// normalized to "#N" so repeats of the same set/value collapse into one line.
+	internal static string ReasonHistogram(IReadOnlyList<ImportIssue> errors, int maxReasons)
+	{
+		var groups = errors
+			.GroupBy(e => Regex.Replace(e.Reason, @"#\d+", "#N"))
+			.OrderByDescending(g => g.Count())
+			.ToList();
+
+		var listed = string.Join("\n", groups.Take(maxReasons).Select(g => $"- {g.Count()}× {g.Key}"));
+
+		return groups.Count > maxReasons
+			? listed + $"\n- … and {groups.Count - maxReasons} more distinct reasons"
+			: listed;
+	}
+}


### PR DESCRIPTION
Closes #106.

The **Report to GitHub** flow downloaded an error CSV and asked the reporter to drag it into the prefilled issue — the step that misfired in #102, where the wrong file got attached twice. This embeds the error data directly in the issue body so there's usually nothing to attach.

## What the generated body now contains

- **Reason histogram** — normalizes per-row collector numbers (`#2`, `#3`, …) to `#N` so repeats of the same set/value aggregate into one counted line (e.g. `27× No printing at GK2_AZORIU #N`, `5× Invalid value 'Surge Foil' for column 'Foil'`). Capped at 20 with an overflow line.
- **Raw error rows inline** in a fenced CSV block, dropped from the end until the prefilled URL fits under GitHub's length cap.
- **Download + attach note only when trimmed** — small/medium reports are fully self-contained; the attachment step appears only for large ones.

## Structure

The body/URL/histogram building moved out of `MtgCsvProcessor.razor` into `ImportErrorReport` in the core library, so the generated body is unit-tested. The `.razor` handlers are now thin delegations.

## Tests

`ImportErrorReportTests` covers: reason normalization/aggregation, the histogram cap + overflow line, full-embed (not trimmed), large-report trimming with the truncation note, the URL staying under the cap, and CSV header/quoting. Full suite green.

Follow-up to #102.
