### PR TITLE
Append TCGplayer variant suffixes to exported card names (#23 MVP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Unreleased work targets the next minor version once a coherent feature set is re
 
 ## [Unreleased]
 
+### Added
+
+- **TCGplayer variant names on export** ([#23](https://github.com/StepKie/MtgCsvHelper/issues/23)). Borderless / Showcase / Extended Art printings now get TCGplayer's parenthetical suffix appended to a `Name` column (`Orcish Bowmasters (Borderless)`), so TCGplayer's name-matching importer resolves the correct printing instead of the default one; `Simple Name` stays plain. Derived from the bundled catalog's `border_color` / `frame_effects` — no extra lookups. (Pending verification against a real TCGplayer import; foil treatments and Retro Frame are follow-ups.)
+
 ## [1.4.1] — 2026-05-31
 
 ### Fixed

--- a/MtgCsvHelper.Tests/TcgplayerVariantNameTests.cs
+++ b/MtgCsvHelper.Tests/TcgplayerVariantNameTests.cs
@@ -1,0 +1,45 @@
+namespace MtgCsvHelper.Tests;
+
+public class TcgplayerVariantNameTests
+{
+	static ReferenceCard Ref(string? borderColor = null, IReadOnlyList<string>? frameEffects = null) =>
+		new(Id: Guid.NewGuid(), OracleId: null, Name: "Orcish Bowmasters", Set: "LTR", SetName: "…",
+			CollectorNumber: "433", Lang: "en", Layout: "normal", Finishes: [], FrameEffects: frameEffects,
+			BorderColor: borderColor, PromoTypes: null, CardmarketId: null, TcgplayerId: null,
+			TcgplayerEtchedId: null, MultiverseIds: null);
+
+	[Fact]
+	public void Borderless_BorderColor_MapsToBorderlessSuffix() =>
+		TcgplayerVariantName.SuffixFor(Ref(borderColor: "borderless")).Should().Be("(Borderless)");
+
+	[Theory]
+	[InlineData("showcase", "(Showcase)")]
+	[InlineData("extendedart", "(Extended Art)")]
+	public void FrameEffect_MapsToSuffix(string frameEffect, string expected) =>
+		TcgplayerVariantName.SuffixFor(Ref(frameEffects: [frameEffect])).Should().Be(expected);
+
+	[Theory]
+	[InlineData("legendary")]
+	[InlineData("inverted")]
+	[InlineData("enchantment")]
+	public void NonVariantFrameEffects_ProduceNoSuffix(string frameEffect) =>
+		TcgplayerVariantName.SuffixFor(Ref(frameEffects: [frameEffect])).Should().BeNull();
+
+	[Fact]
+	public void NormalPrinting_HasNoSuffix() =>
+		TcgplayerVariantName.SuffixFor(Ref(borderColor: "black")).Should().BeNull();
+
+	[Fact]
+	public void Borderless_TakesPrecedence_OverFrameEffects() =>
+		TcgplayerVariantName.SuffixFor(Ref(borderColor: "borderless", frameEffects: ["showcase"])).Should().Be("(Borderless)");
+
+	[Fact]
+	public void Decorate_AppendsSuffix_WhenVariant() =>
+		TcgplayerVariantName.Decorate("Orcish Bowmasters", Ref(borderColor: "borderless"))
+			.Should().Be("Orcish Bowmasters (Borderless)");
+
+	[Fact]
+	public void Decorate_LeavesNamePlain_WhenNormal() =>
+		TcgplayerVariantName.Decorate("Orcish Bowmasters", Ref(borderColor: "black"))
+			.Should().Be("Orcish Bowmasters");
+}

--- a/MtgCsvHelper.Tests/TcgplayerWriteTests.cs
+++ b/MtgCsvHelper.Tests/TcgplayerWriteTests.cs
@@ -1,0 +1,62 @@
+using System.Text;
+using ScryfallApi.Client.Models;
+
+namespace MtgCsvHelper.Tests;
+
+[Collection(CatalogCollection.Name)]
+public class TcgplayerWriteTests(CatalogFixture fixture, ITestOutputHelper output) : ApiBaseTest(fixture, output)
+{
+	static PhysicalMtgCard Card(string name, string set, string collectorNumber) => new()
+	{
+		Count = 1,
+		Condition = CardCondition.NEAR_MINT,
+		Foil = false,
+		Language = "en",
+		Printing = new Card { Name = name, Set = set, SetName = "", CollectorNumber = collectorNumber },
+	};
+
+	string WriteTcgplayer(params PhysicalMtgCard[] cards)
+	{
+		var handler = new MtgCardCsvHandler(_catalog, _resolver, _config, "TCGPLAYER");
+		using var stream = new MemoryStream();
+		handler.WriteCollectionCsv(cards, stream);
+
+		return Encoding.UTF8.GetString(stream.ToArray());
+	}
+
+	[Fact]
+	public void BorderlessPrinting_GetsVariantSuffixInNameColumn_SimpleNameStaysPlain()
+	{
+		// LTR #433 is the borderless Orcish Bowmasters; #103 is the normal printing.
+		var csv = WriteTcgplayer(Card("Orcish Bowmasters", "LTR", "433"));
+
+		// Both headers are emitted as standalone columns (not just "Name" as a substring of "Simple Name").
+		var headers = csv.Split('\n').First(l => l.Contains("Simple Name")).Split(',').Select(h => h.Trim().Trim('"')).ToList();
+		headers.Should().Contain("Name").And.Contain("Simple Name");
+		csv.Should().Contain("Orcish Bowmasters (Borderless)");
+
+		// Simple Name stays plain: strip the decorated occurrence and the bare name must still be present.
+		var dataLine = csv.Split('\n').First(l => l.Contains("Orcish Bowmasters"));
+		dataLine.Should().Contain("Orcish Bowmasters (Borderless)");
+		dataLine.Replace("Orcish Bowmasters (Borderless)", "").Should().Contain("Orcish Bowmasters");
+	}
+
+	[Fact]
+	public void NormalPrinting_NameMatchesSimpleName()
+	{
+		var csv = WriteTcgplayer(Card("Orcish Bowmasters", "LTR", "103"));
+
+		csv.Should().NotContain("(Borderless)");
+		csv.Should().Contain("Orcish Bowmasters");
+	}
+
+	[Fact]
+	public void UnknownPrinting_FallsBackToPlainName()
+	{
+		// Collector number "999" doesn't exist in the catalog — the map must fall back to the plain name, not throw.
+		var csv = WriteTcgplayer(Card("Orcish Bowmasters", "LTR", "999"));
+
+		csv.Should().Contain("Orcish Bowmasters");
+		csv.Should().NotContain("(Borderless)").And.NotContain("(Showcase)").And.NotContain("(Extended Art)");
+	}
+}

--- a/MtgCsvHelper/CardMapFactory.cs
+++ b/MtgCsvHelper/CardMapFactory.cs
@@ -11,10 +11,7 @@ public class CardMapFactory(IConfiguration config, IReferenceCardCatalog catalog
 	public static IReadOnlyList<string> Supported { get; } = ["MOXFIELD", "DRAGONSHIELD", "MANABOX", "TOPDECKED", "DECKBOX", "CARDKINGDOM", "MTGGOLDFISH", "TCGPLAYER", "CARDMARKET", "ARCHIDEKT", "MTGO"];
 	public static IReadOnlyList<string> NotYetFullySupported { get; } = ["URZAGATHERER"];
 
-	// Formats whose CSV doesn't carry enough info to populate a complete card without external lookups,
-	// or that don't make sense as targets for our writers. Internal so tests can derive expectations
-	// from the same source of truth as the Readable/Writable filters below. Declared as IReadOnlySet
-	// so the assembly-internal exposure can't accidentally mutate the contents.
+	// Write-only / read-only format sets; internal so tests derive expectations from the same source of truth.
 	internal static readonly IReadOnlySet<string> WriteOnlyFormats = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CARDKINGDOM" };
 	internal static readonly IReadOnlySet<string> ReadOnlyFormats = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CARDMARKET" };
 
@@ -55,6 +52,7 @@ public class CardMapFactory(IConfiguration config, IReferenceCardCatalog catalog
 		if (format.Equals("CARDKINGDOM", StringComparison.OrdinalIgnoreCase)) { return new CardKingdomWriteMap(cfg, catalog); }
 		if (format.Equals("DECKBOX", StringComparison.OrdinalIgnoreCase)) { return new DeckboxMap(cfg, catalog); }
 		if (format.Equals("DRAGONSHIELD", StringComparison.OrdinalIgnoreCase)) { return new DragonShieldMap(cfg, catalog); }
+		if (format.Equals("TCGPLAYER", StringComparison.OrdinalIgnoreCase)) { return new TCGPlayerWriteMap(cfg, catalog); }
 		return new PhysicalCardMap(cfg, catalog);
 	}
 

--- a/MtgCsvHelper/Maps/TCGPlayerWriteMap.cs
+++ b/MtgCsvHelper/Maps/TCGPlayerWriteMap.cs
@@ -1,0 +1,24 @@
+namespace MtgCsvHelper.Maps;
+
+/// <summary>
+/// Extends <see cref="PhysicalCardMap"/> with a TCGplayer-specific <c>Name</c> column carrying the
+/// base name plus the variant suffix (<c>(Borderless)</c>/<c>(Showcase)</c>/<c>(Extended Art)</c>)
+/// that TCGplayer's name-matching importer needs to resolve the correct printing; <c>Simple Name</c>
+/// (from the base map) stays plain. Write-only — reads use the plain <c>Simple Name</c> via the base map.
+/// </summary>
+public sealed class TCGPlayerWriteMap : PhysicalCardMap
+{
+	public TCGPlayerWriteMap(FormatConfig cfg, IReferenceCardCatalog catalog) : base(cfg, catalog)
+	{
+		// useExistingMap: false — the base map already maps Printing.Name to "Simple Name", so this adds a second, independent column.
+		Map(c => c.Printing.Name, useExistingMap: false).Name("Name").Convert(args =>
+		{
+			var printing = args.Value.Printing;
+			var reference = string.IsNullOrEmpty(printing.Set) || string.IsNullOrEmpty(printing.CollectorNumber)
+				? null
+				: catalog.FindBySetAndCollectorNumber(printing.Set, printing.CollectorNumber);
+
+			return reference is null ? printing.Name : TcgplayerVariantName.Decorate(printing.Name, reference);
+		});
+	}
+}

--- a/MtgCsvHelper/TcgplayerVariantName.cs
+++ b/MtgCsvHelper/TcgplayerVariantName.cs
@@ -1,0 +1,28 @@
+namespace MtgCsvHelper;
+
+/// <summary>
+/// Maps a printing's Scryfall attributes to the parenthetical variant suffix TCGplayer appends to
+/// a card name (e.g. "Orcish Bowmasters (Borderless)"). TCGplayer's importer matches by name, so a
+/// borderless/showcase/extended-art printing only resolves if the suffix is present — the collector
+/// number alone isn't enough.
+/// </summary>
+public static class TcgplayerVariantName
+{
+	/// <summary>The TCGplayer variant suffix for a printing (e.g. <c>"(Borderless)"</c>), or null if it's a normal printing.</summary>
+	public static string? SuffixFor(ReferenceCard card)
+	{
+		// Order is TCGplayer's precedence when a printing carries more than one treatment.
+		if (string.Equals(card.BorderColor, "borderless", StringComparison.OrdinalIgnoreCase)) { return "(Borderless)"; }
+		if (HasFrameEffect(card, "showcase")) { return "(Showcase)"; }
+		if (HasFrameEffect(card, "extendedart")) { return "(Extended Art)"; }
+
+		return null;
+	}
+
+	/// <summary><paramref name="baseName"/> with the variant suffix appended when the printing has one.</summary>
+	public static string Decorate(string baseName, ReferenceCard card) =>
+		SuffixFor(card) is { } suffix ? $"{baseName} {suffix}" : baseName;
+
+	static bool HasFrameEffect(ReferenceCard card, string effect) =>
+		card.FrameEffects?.Any(e => string.Equals(e, effect, StringComparison.OrdinalIgnoreCase)) == true;
+}


### PR DESCRIPTION
Addresses #23 (MVP).

TCGplayer's importer matches by **name**, so a Borderless/Showcase/Extended Art printing only resolves if the variant suffix is present — the collector number alone isn't enough. Exports now emit a `Name` column = base name + suffix (`Orcish Bowmasters (Borderless)`), with `Simple Name` kept plain.

## Why this is feasible now

The original blocker ("would have to fetch + parse each card from Scryfall at conversion time") is gone: the app bundles the full Scryfall catalog in memory, every `ReferenceCard` carries `border_color`/`frame_effects`, and import already does an O(1) `FindBySetAndCollectorNumber`. The suffix is a free local derivation.

## What's here

- `TcgplayerVariantName` — pure, testable `ReferenceCard` → suffix mapping (`(Borderless)`/`(Showcase)`/`(Extended Art)`), with precedence; non-variant frame effects (legendary/inverted/…) produce no suffix.
- `TCGPlayerWriteMap` — adds the `Name` column via a whole-card `.Convert` that looks the printing up by `(Set, CollectorNumber)`. Write-only; reads keep using the plain `Simple Name`.
- 9 tests (helper + precedence + the two write cases, incl. the reporter's `LTR` #433 vs #103). Suite green (214).

## Scope / caveats

- **MVP = the three common art variants.** Foil treatments (Surge/Galaxy/…) and `(Retro Frame)` (needs Scryfall's `frame` field, not yet bundled) are follow-ups.
- **Needs verification against a real TCGplayer import** — I have no Level-4 seller account, so this wants @mhbw (the reporter) to confirm the output is accepted, same model as the recent Dragon Shield round-trip verification.
- A fully-exact alternative (lookup by `TcgplayerId` against tcgcsv product names) is noted in the issue as the fidelity follow-up.
