### PR TITLE
Fix DFC name loss on round-trip through ShortNames=true formats (#94)

### DIFF
--- a/MtgCsvHelper.Tests/CatalogValidatorTests.cs
+++ b/MtgCsvHelper.Tests/CatalogValidatorTests.cs
@@ -1,0 +1,76 @@
+using MtgCsvHelper.Enrichment;
+using ScryfallApi.Client.Models;
+
+namespace MtgCsvHelper.Tests;
+
+[Collection(CatalogCollection.Name)]
+public class CatalogValidatorTests(CatalogFixture fixture)
+{
+	readonly CatalogValidator _validator = new(fixture.Catalog);
+
+	// TWOE #15's front face "Monster" is shared by several DFCs, so expanding it picks an arbitrary one.
+	const string SharedFrontSet = "TWOE";
+	const string SharedFrontNumber = "15";
+	const string SharedFront = "Monster";
+
+	static ParsedRow Row(string name, string set, string collectorNumber) =>
+		new(new PhysicalMtgCard
+		{
+			Count = 1,
+			Printing = new Card { Name = name, Set = set, CollectorNumber = collectorNumber, SetName = "" },
+		}, RowNumber: 1);
+
+	async Task<(List<ParsedRow> kept, List<ImportIssue> issues)> Validate(ParsedRow row)
+	{
+		List<ParsedRow> rows = [row];
+		List<ImportIssue> issues = [];
+		await _validator.EnrichAsync(rows, issues, CancellationToken.None);
+
+		return (rows, issues);
+	}
+
+	[Fact]
+	public async Task FrontFaceOnlyShortName_IsAcceptedAndCanonicalized()
+	{
+		var canonical = fixture.Catalog.FindBySetAndCollectorNumber(SharedFrontSet, SharedFrontNumber)!.Name;
+		var (kept, issues) = await Validate(Row(SharedFront, SharedFrontSet, SharedFrontNumber));
+
+		issues.Should().BeEmpty();
+		kept.Should().ContainSingle().Which.Card.Printing.Name.Should().Be(canonical);
+	}
+
+	// A wrongly-expanded full name at a (Set, #) pinning a different printing must be accepted and corrected, not dropped.
+	[Fact]
+	public async Task WronglyExpandedSharedFrontFace_IsAcceptedAndCanonicalized()
+	{
+		var canonical = fixture.Catalog.FindBySetAndCollectorNumber(SharedFrontSet, SharedFrontNumber)!.Name;
+		var arbitraryExpansion = fixture.Catalog.ExpandFrontFaceToFullName(SharedFront);
+		arbitraryExpansion.Should().NotBeNullOrEmpty(because: "the shared front face must expand to some DFC full name");
+		arbitraryExpansion.Should().NotBe(canonical,
+			because: "the bug only reproduces when the arbitrary expansion differs from the printing pinned by (Set, #)");
+
+		var (kept, issues) = await Validate(Row(arbitraryExpansion!, SharedFrontSet, SharedFrontNumber));
+
+		issues.Should().BeEmpty();
+		kept.Should().ContainSingle().Which.Card.Printing.Name.Should().Be(canonical);
+	}
+
+	[Fact]
+	public async Task ExactCanonicalName_PassesThroughUnchanged()
+	{
+		var canonical = fixture.Catalog.FindBySetAndCollectorNumber(SharedFrontSet, SharedFrontNumber)!.Name;
+		var (kept, issues) = await Validate(Row(canonical, SharedFrontSet, SharedFrontNumber));
+
+		issues.Should().BeEmpty();
+		kept.Should().ContainSingle().Which.Card.Printing.Name.Should().Be(canonical);
+	}
+
+	[Fact]
+	public async Task WrongName_AtValidSetAndNumber_IsDropped()
+	{
+		var (kept, issues) = await Validate(Row("Lightning Bolt", SharedFrontSet, SharedFrontNumber));
+
+		kept.Should().BeEmpty();
+		issues.Should().ContainSingle().Which.Severity.Should().Be(IssueSeverity.Error);
+	}
+}

--- a/MtgCsvHelper/Enrichment/CatalogValidator.cs
+++ b/MtgCsvHelper/Enrichment/CatalogValidator.cs
@@ -31,21 +31,17 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 			return false;
 		}
 
-		if (EqualsNormalized(p.Name, match.Name))
+		if (!EqualsNormalized(p.Name, match.Name))
 		{
-			// Names already agree (diacritics aside) — keep the imported spelling for round-trip safety.
-		}
-		else if (EqualsNormalized(FrontFace(p.Name), FrontFace(match.Name)))
-		{
+			if (!EqualsNormalized(FrontFace(p.Name), FrontFace(match.Name)))
+			{
+				issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
+					$"Name '{p.Name}' does not match printing at {p.Set} #{p.CollectorNumber} ('{match.Name}')",
+					CardName: p.Name, RawContent: row.RawContent));
+				return false;
+			}
 			// (Set, #) already pins the printing; adopt its canonical name for a short or shared-front-face import.
 			p.Name = match.Name;
-		}
-		else
-		{
-			issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
-				$"Name '{p.Name}' does not match printing at {p.Set} #{p.CollectorNumber} ('{match.Name}')",
-				CardName: p.Name, RawContent: row.RawContent));
-			return false;
 		}
 
 		if (row.Card.Foil is true && !HasFoilFinish(match.Finishes))

--- a/MtgCsvHelper/Enrichment/CatalogValidator.cs
+++ b/MtgCsvHelper/Enrichment/CatalogValidator.cs
@@ -6,8 +6,9 @@ namespace MtgCsvHelper.Enrichment;
 /// <summary>
 /// The one validator in the post-parse pipeline. Drops rows whose (Set, CollectorNumber)
 /// doesn't resolve, whose Name doesn't match the resolved printing, or whose Foil flag
-/// claims an unsupported finish. Named "Validator" rather than "Enricher" because it
-/// checks-and-drops; the only mutation it makes is to the issues collection.
+/// claims an unsupported finish. Named "Validator" rather than "Enricher" because it mainly
+/// checks-and-drops; its only mutations are the issues collection and canonicalizing the
+/// name of a short-named or front-face-ambiguous double-faced card to the resolved printing.
 /// </summary>
 public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnricher
 {
@@ -30,7 +31,16 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 			return false;
 		}
 
-		if (!NamesMatch(p.Name, match.Name, catalog))
+		if (EqualsNormalized(p.Name, match.Name))
+		{
+			// Names already agree (diacritics aside) — keep the imported spelling for round-trip safety.
+		}
+		else if (EqualsNormalized(FrontFace(p.Name), FrontFace(match.Name)))
+		{
+			// (Set, #) already pins the printing; adopt its canonical name for a short or shared-front-face import.
+			p.Name = match.Name;
+		}
+		else
 		{
 			issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
 				$"Name '{p.Name}' does not match printing at {p.Set} #{p.CollectorNumber} ('{match.Name}')",
@@ -49,13 +59,8 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 		return true;
 	}
 
-	static bool NamesMatch(string imported, string referenceName, IReferenceCardCatalog catalog)
-	{
-		if (EqualsNormalized(imported, referenceName)) { return true; }
-		// Front-face-only imports (Moxfield's ShortNames=false formats) match the full Scryfall name.
-		var expanded = catalog.ExpandFrontFaceToFullName(imported);
-		return expanded is not null && EqualsNormalized(expanded, referenceName);
-	}
+	// Front face of a DFC name ("A // B" → "A"); a name without " // " is its own front face.
+	static string FrontFace(string name) => name.Split(" // ")[0];
 
 	// Compares with Unicode diacritic stripping (NFD + remove combining marks). TCGPlayer and a
 	// few other sites normalize "Lim-Dûl's Vault" → "Lim-Dul's Vault" on export; Scryfall keeps the


### PR DESCRIPTION
Closes #94.

## The bug

Round-tripping a collection through any `ShortNames=true` format (e.g. Moxfield → Dragon Shield → Moxfield) dropped or corrupted double-faced cards whose **front face is shared by several DFCs in the same set** — e.g. The One Ring's two `Monster` cards (`Monster // Sorcerer` and `Monster // Virtuous`).

On read-back, `CardNameConverter` calls `catalog.ExpandFrontFaceToFullName("Monster")`, which has no `(Set, #)` to disambiguate and returns whichever DFC was inserted last. `CatalogValidator` then compared that arbitrary name against the printing pinned by `(Set, #)`, found a mismatch, and dropped the row with `Name '…' does not match printing at …`.

## The fix

`NamesMatch` is only reached **after** a successful `(Set, #)` lookup — so the resolved printing's true name is already in hand. Compare front faces directly against it instead of re-expanding the ambiguous short name, and adopt the canonical full name when they agree so a later full-name export emits the correct card.

- The exact-match path leaves the imported spelling untouched, preserving the existing diacritic round-trip behavior (`Lim-Dûl's` ↔ `Lim-Dul's`).
- The `ExpandFrontFaceToFullName` call in the validator is now unreachable and removed. The catalog method stays — `CardNameConverter` still uses it.

## Tests

New `CatalogValidatorTests` (4 cases), with expectations derived from the live catalog rather than hardcoded back-faces:

- front-face-only short name → kept + canonicalized
- wrongly-expanded shared front face → kept + canonicalized (the regression, with a precondition assert that the scenario genuinely reproduces)
- exact canonical name → unchanged
- genuinely wrong name at a valid `(Set, #)` → dropped

Full suite: 219 passed / 0 failed.