### PR TITLE
Guard against non-seekable streams in ParseCollectionCsv (#73)

### DIFF
--- a/MtgCsvHelper.Tests/FaultToleranceTests.cs
+++ b/MtgCsvHelper.Tests/FaultToleranceTests.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using System.Text;
 using CsvHelper;
 
@@ -119,6 +120,17 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 		result.Issues.Should().NotContain(i => i.Severity == IssueSeverity.Error);
 		result.Collection.Cards.Should().ContainSingle()
 			.Which.Printing.Set.Should().Be("GK2");
+	}
+
+	[Fact]
+	public void NonSeekableStream_ThrowsArgumentExceptionEarly()
+	{
+		// GZipStream is the canonical non-seekable stream; the guard must fire before any read.
+		using var nonSeekable = new GZipStream(new MemoryStream(), CompressionMode.Decompress);
+
+		var act = () => Handler().ParseCollectionCsv(nonSeekable);
+
+		act.Should().Throw<ArgumentException>().WithParameterName("csvStream").WithMessage("*seekable*");
 	}
 
 	[Fact]

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -38,8 +38,11 @@ public class MtgCardCsvHandler
 
 	public Task<ParseResult> ParseCollectionCsvAsync(string csvFilePath, CancellationToken ct = default) => ParseCollectionCsvAsync(File.OpenRead(csvFilePath), ct);
 
+	/// <summary> Parses a collection CSV. <paramref name="csvStream"/> must be seekable: the parser peeks at the first line for a "sep=" marker and rewinds. </summary>
 	public async Task<ParseResult> ParseCollectionCsvAsync(Stream csvStream, CancellationToken ct = default)
 	{
+		if (!csvStream.CanSeek) { throw new ArgumentException("Stream must be seekable", nameof(csvStream)); }
+
 		Log.Information($"Parsing input format {_format} ...");
 		using var reader = new StreamReader(csvStream);
 		CheckIfFirstLineCanBeIgnored(reader);


### PR DESCRIPTION
Implements option C from #73: an early `ArgumentException("Stream must be seekable", nameof(csvStream))` at the top of `ParseCollectionCsvAsync`, plus a one-line xmldoc stating the contract.

`CheckIfFirstLineCanBeIgnored` rewinds the stream after peeking for a Dragon Shield `sep=` first-line marker, which previously threw an opaque `NotSupportedException` deep inside the peek on non-seekable streams. All current callers pass seekable streams (`FileStream` from the Console path, `MemoryStream` from Blazor), so failing fast at the boundary beats refactoring the peek to buffer for a hypothetical caller.

Test: `NonSeekableStream_ThrowsArgumentExceptionEarly` uses a `GZipStream` as the canonical non-seekable stream and asserts the guard fires before any read.

Closes #73