### PR TITLE
Resolve surviving inline TODOs: rarity stats, CLI parse errors, token encoding (#71)

### DIFF
--- a/MtgCsvHelper.Console/Program.cs
+++ b/MtgCsvHelper.Console/Program.cs
@@ -124,4 +124,5 @@ void RunWithOptions(CommandLineOptions opts)
 
 	writer.WriteCollectionCsv(cardsFound);
 }
-void HandleParseError(IEnumerable<Error> errs) => Console.WriteLine(string.Join(",", errs)); // TODO: handle errors
+// Parser.Default already printed usage/help to stderr; our job is just the exit code (0 for --help/--version, 1 for real parse errors so CI fails).
+void HandleParseError(IEnumerable<Error> errs) => Environment.Exit(errs.All(e => e.Tag is ErrorType.HelpRequestedError or ErrorType.VersionRequestedError) ? 0 : 1);

--- a/MtgCsvHelper.Tests/CatalogValidatorTests.cs
+++ b/MtgCsvHelper.Tests/CatalogValidatorTests.cs
@@ -66,6 +66,18 @@ public class CatalogValidatorTests(CatalogFixture fixture)
 	}
 
 	[Fact]
+	public async Task ValidatedRow_GetsRarityBackfilledFromCatalog()
+	{
+		var expected = fixture.Catalog.FindBySetAndCollectorNumber(SharedFrontSet, SharedFrontNumber)!.Rarity;
+		expected.Should().NotBe(CardRarity.Unknown, because: "the bundle carries rarity for every printing");
+
+		var (kept, issues) = await Validate(Row(SharedFront, SharedFrontSet, SharedFrontNumber));
+
+		issues.Should().BeEmpty();
+		kept.Should().ContainSingle().Which.Card.Rarity.Should().Be(expected);
+	}
+
+	[Fact]
 	public async Task WrongName_AtValidSetAndNumber_IsDropped()
 	{
 		var (kept, issues) = await Validate(Row("Lightning Bolt", SharedFrontSet, SharedFrontNumber));

--- a/MtgCsvHelper.Tests/CollectionTests.cs
+++ b/MtgCsvHelper.Tests/CollectionTests.cs
@@ -1,0 +1,42 @@
+using ScryfallApi.Client.Models;
+
+namespace MtgCsvHelper.Tests;
+
+public class CollectionTests
+{
+	static PhysicalMtgCard CardOf(string name, CardRarity rarity, int count) =>
+		new() { Count = count, Printing = new Card { Name = name }, Rarity = rarity };
+
+	[Fact]
+	public void GenerateSummary_BreaksDownCountsByRarity()
+	{
+		var collection = new Collection
+		{
+			Name = "Test",
+			Cards =
+			[
+				CardOf("Lightning Bolt", CardRarity.Common, 4),
+				CardOf("Counterspell", CardRarity.Common, 2),
+				CardOf("Wrath of God", CardRarity.Rare, 1),
+			],
+		};
+
+		var summary = collection.GenerateSummary();
+
+		summary.Should().Contain("Common: 6").And.Contain("Rare: 1");
+	}
+
+	[Fact]
+	public void GenerateSummary_SkipsCardsWithUnknownRarity()
+	{
+		var collection = new Collection
+		{
+			Name = "Test",
+			Cards = [CardOf("Mystery Card", CardRarity.Unknown, 3)],
+		};
+
+		var summary = collection.GenerateSummary();
+
+		summary.Should().NotContain("Unknown");
+	}
+}

--- a/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
+++ b/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
@@ -174,6 +174,7 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 				SetName = "Innistrad: Midnight Hunt",
 			},
 			Language = "en",
+			Rarity = CardRarity.Uncommon,
 		};
 
         var card2 = card1 with { Language = "zht" };
@@ -208,6 +209,7 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 			},
 			Language = "en",
 			PriceBought = new Money(0.15m, currency),
+			Rarity = CardRarity.Common,
 		};
 
 		var card9 = new PhysicalMtgCard
@@ -224,6 +226,7 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 			},
 			Language = "en",
 			PriceBought = new Money(0.11m, currency),
+			Rarity = CardRarity.Common,
 		};
 
 		return [card1, card2, card3, card4, card5, card6, card7, card8, card9];

--- a/MtgCsvHelper/Converters/CardNameConverter.cs
+++ b/MtgCsvHelper/Converters/CardNameConverter.cs
@@ -37,8 +37,7 @@ public class CardNameConverter(CardNameConfiguration configuration, IReferenceCa
 			}
 		}
 
-		// Remove " Token" from the end of the card name to adhere to Scryfall's naming convention
-		// TODO When converting to Moxfield, we would need to add it back in. The only way to detect this is to check if SetID has 4 characters, starting with a "T" (e.g. TMH2 or similar)
+		// Formats with EncodeToken decorate token names (e.g. Dragon Shield's "Beast Token"); re-add the suffix the read path stripped.
 		if (_encodeToken && catalog.IsTokenName(cardName)) { cardName += " Token"; }
 
 		return cardName;

--- a/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
+++ b/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
@@ -46,6 +46,7 @@ public sealed class CardmarketIdEnricher(ICardmarketResolver resolver) : IEnrich
 				row.Card.Printing.Set = full.Set;
 				row.Card.Printing.SetName = full.SetName;
 				row.Card.Printing.CollectorNumber = full.CollectorNumber;
+				rows[i] = row with { Card = row.Card with { Rarity = full.Rarity } };
 			}
 			else
 			{

--- a/MtgCsvHelper/Enrichment/CatalogValidator.cs
+++ b/MtgCsvHelper/Enrichment/CatalogValidator.cs
@@ -7,12 +7,13 @@ namespace MtgCsvHelper.Enrichment;
 /// The one validator in the post-parse pipeline. Drops rows whose (Set, CollectorNumber)
 /// doesn't resolve, whose Name doesn't match the resolved printing, or whose Foil flag
 /// claims an unsupported finish. Named "Validator" rather than "Enricher" because it mainly
-/// checks-and-drops; its only mutations are the issues collection and canonicalizing the
-/// name of a short-named or front-face-ambiguous double-faced card to the resolved printing.
+/// checks-and-drops; its only mutations are the issues collection, canonicalizing the
+/// name of a short-named or front-face-ambiguous double-faced card to the resolved printing,
+/// and backfilling Rarity from the resolved printing (no import format feeds it).
 /// </summary>
 public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnricher
 {
-	protected override bool EnrichOne(ParsedRow row, ICollection<ImportIssue> issues)
+	protected override bool EnrichOne(ref ParsedRow row, ICollection<ImportIssue> issues)
 	{
 		var p = row.Card.Printing;
 		// No catalog lookup is possible without (Name, Set, CollectorNumber). Rows missing any
@@ -51,6 +52,8 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 				CardName: p.Name, RawContent: row.RawContent));
 			return false;
 		}
+
+		row = row with { Card = row.Card with { Rarity = match.Rarity } };
 
 		return true;
 	}

--- a/MtgCsvHelper/Enrichment/PerCardEnricher.cs
+++ b/MtgCsvHelper/Enrichment/PerCardEnricher.cs
@@ -13,7 +13,12 @@ public abstract class PerCardEnricher : IEnricher
 		for (int i = rows.Count - 1; i >= 0; i--)
 		{
 			ct.ThrowIfCancellationRequested();
-			if (!EnrichOne(rows[i], issues))
+			var row = rows[i];
+			if (EnrichOne(ref row, issues))
+			{
+				rows[i] = row;
+			}
+			else
 			{
 				rows.RemoveAt(i);
 			}
@@ -21,6 +26,7 @@ public abstract class PerCardEnricher : IEnricher
 		return Task.CompletedTask;
 	}
 
+	/// <summary> The row is passed by reference so implementations can replace it (records are immutable). </summary>
 	/// <returns><c>true</c> to keep the row, <c>false</c> to drop it.</returns>
-	protected abstract bool EnrichOne(ParsedRow row, ICollection<ImportIssue> issues);
+	protected abstract bool EnrichOne(ref ParsedRow row, ICollection<ImportIssue> issues);
 }

--- a/MtgCsvHelper/Enrichment/SetInfoEnricher.cs
+++ b/MtgCsvHelper/Enrichment/SetInfoEnricher.cs
@@ -10,7 +10,7 @@ namespace MtgCsvHelper.Enrichment;
 /// </summary>
 public sealed class SetInfoEnricher(IReferenceCardCatalog catalog) : PerCardEnricher
 {
-	protected override bool EnrichOne(ParsedRow row, ICollection<ImportIssue> issues)
+	protected override bool EnrichOne(ref ParsedRow row, ICollection<ImportIssue> issues)
 	{
 		var p = row.Card.Printing;
 		// Skip rows that have no Name — there's nothing meaningful to enrich without a card

--- a/MtgCsvHelper/Models/CardRarity.cs
+++ b/MtgCsvHelper/Models/CardRarity.cs
@@ -1,0 +1,13 @@
+namespace MtgCsvHelper.Models;
+
+/// <summary> Scryfall printing rarity, ordered as Scryfall documents it after <see cref="Unknown"/>. </summary>
+public enum CardRarity
+{
+	Unknown,
+	Common,
+	Uncommon,
+	Rare,
+	Special,
+	Mythic,
+	Bonus,
+}

--- a/MtgCsvHelper/Models/Collection.cs
+++ b/MtgCsvHelper/Models/Collection.cs
@@ -25,13 +25,15 @@ public record Collection
 			sb.AppendLine($"Most expensive card: {mostExpensive.Printing.Name} ({mostExpensive.PriceBought.Print()})");
 		}
 
-		// TODO Will work when we have queried data from Scryfall regarding the cards
-		//Dictionary<string, int> cardsByRarity = Cards.GroupBy(c => c.Printing.Rarity).ToDictionary(g => g.Key, g => g.Sum(c => c.Count));
+		var rarityCounts = Cards
+			.Where(c => c.Rarity != CardRarity.Unknown)
+			.GroupBy(c => c.Rarity, (rarity, group) => (Rarity: rarity, Amount: group.Sum(c => c.Count)))
+			.OrderBy(rc => rc.Rarity);
 
-		//foreach (var (rarity, amount) in cardsByRarity)
-		//{
-		//	sb.AppendLine($"{rarity}: {amount}");
-		//}
+		foreach (var (rarity, amount) in rarityCounts)
+		{
+			sb.AppendLine($"{rarity}: {amount}");
+		}
 
 		sb.AppendLine("-------------------");
 

--- a/MtgCsvHelper/Models/PhysicalMtgCard.cs
+++ b/MtgCsvHelper/Models/PhysicalMtgCard.cs
@@ -29,4 +29,7 @@ public record PhysicalMtgCard
 	public DateTime? DateBought { get; init; }
 
 	public bool? TradeListed { get; init; }
+
+	// No format maps a rarity column; backfilled from the catalog once the printing resolves.
+	public CardRarity Rarity { get; init; } = CardRarity.Unknown;
 }

--- a/MtgCsvHelper/ReferenceCard.cs
+++ b/MtgCsvHelper/ReferenceCard.cs
@@ -1,13 +1,16 @@
+using MtgCsvHelper.Models;
+
 namespace MtgCsvHelper;
 
 /// <summary>
 /// Stripped Scryfall Card record, the canonical printing reference shipped as
-/// a build-time bundle (~7 MB gzipped, ~80k printings). Fields chosen to support:
+/// a build-time bundle (~11 MB gzipped, ~115k printings). Fields chosen to support:
 /// <list type="bullet">
 /// <item>identity resolution by Scryfall id, cardmarket_id, tcgplayer_id, set+collector_number, multiverse_id</item>
 /// <item>inconsistency detection (foil claimed but printing has no foil finish; set+collector_number out of range; etc.)</item>
 /// <item>derived attribute computation (e.g. "(Borderless)" suffix from <see cref="BorderColor"/>/<see cref="FrameEffects"/>)</item>
 /// <item>double-faced + token detection from <see cref="Layout"/></item>
+/// <item>collection statistics (per-<see cref="Rarity"/> breakdown)</item>
 /// </list>
 /// Always English (the Scryfall <c>default_cards</c> bulk file is English-only). Non-English imports
 /// fall back to a live Scryfall lookup at runtime.
@@ -32,7 +35,9 @@ public sealed record ReferenceCard(
 	// MTGO uses 2-letter codes for older sets (MI, VI, TE...) that don't match Scryfall's
 	// 3-letter codes (mir, vis, tmp...). Populated from the /sets endpoint at bundle build time;
 	// null for sets MTGO doesn't carry. Catalog uses it as a fallback set-code lookup key.
-	string? MtgoCode = null)
+	string? MtgoCode = null,
+	// Unknown in bundles generated before the field existed.
+	CardRarity Rarity = CardRarity.Unknown)
 {
 	// Normalized at construction: Set and MtgoCode are uppercased for any primary-constructor
 	// invocation (factory, JSON deserialization, direct ctor in tests). The catalog's lookup
@@ -60,5 +65,7 @@ public sealed record ReferenceCard(
 		TcgplayerId: c.TcgplayerId,
 		TcgplayerEtchedId: c.TcgplayerEtchedId,
 		MultiverseIds: c.MultiverseIds,
-		MtgoCode: mtgoCode);
+		MtgoCode: mtgoCode,
+		// Boundary conversion: an unrecognized future Scryfall rarity degrades to Unknown instead of failing the import.
+		Rarity: Enum.TryParse<CardRarity>(c.Rarity, ignoreCase: true, out var rarity) ? rarity : CardRarity.Unknown);
 }

--- a/MtgCsvHelper/ReferenceCardCatalog.cs
+++ b/MtgCsvHelper/ReferenceCardCatalog.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace MtgCsvHelper;
 
@@ -123,5 +124,7 @@ public sealed class ReferenceCardCatalog : IReferenceCardCatalog
 	{
 		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
 		PropertyNameCaseInsensitive = true,
+		// Enums (CardRarity) are stored as Scryfall's lowercase strings so the bundle stays greppable.
+		Converters = { new JsonStringEnumConverter(JsonNamingPolicy.SnakeCaseLower) },
 	};
 }

--- a/MtgCsvHelper/Resources/SampleCsvs/Tests/SITE_BEHAVIOR.md
+++ b/MtgCsvHelper/Resources/SampleCsvs/Tests/SITE_BEHAVIOR.md
@@ -39,6 +39,11 @@ Status: 41/41 rows round-trip cleanly (May 2026).
 - Etched is supported in the Foil column (`etched` string). Preserved on round-trip. Our `appsettings.json` encodes this; etched data still collapses to `bool Foil` in our internal model — follow-up.
 - The `Folder Name` column in the collection-export form is critical for grouping; absent from binder exports.
 
+**Tokens (verified by round-trip, June 2026):**
+- Import wants plain Scryfall names with the Scryfall token-set code: `Beast` / `tmh2` / #9, `Clue` / `tmh2` / #15, `Morph` / `tktk` / #11 all import cleanly.
+- Decorated names are rejected: `Beast Token`, `Clue Token`, `Morph Creature` each produce `Could not find card named "<Name>" in edition "<set>"`.
+- Re-export preserves plain names, lowercase set codes, and collector numbers exactly — so the MOXFIELD writer must emit plain names (`EncodeToken` stays unset; only DragonShield decorates).
+
 ---
 
 ## Manabox

--- a/MtgCsvHelper/ScryfallCardJson.cs
+++ b/MtgCsvHelper/ScryfallCardJson.cs
@@ -26,4 +26,5 @@ internal sealed record ScryfallCardJson(
 	[property: JsonPropertyName("cardmarket_id")] int? CardmarketId,
 	[property: JsonPropertyName("tcgplayer_id")] int? TcgplayerId,
 	[property: JsonPropertyName("tcgplayer_etched_id")] int? TcgplayerEtchedId,
-	[property: JsonPropertyName("multiverse_ids")] List<int>? MultiverseIds);
+	[property: JsonPropertyName("multiverse_ids")] List<int>? MultiverseIds,
+	string? Rarity = null);

--- a/tools/MtgCsvHelper.RefreshReferenceData/CardmarketFixtureGenerator.cs
+++ b/tools/MtgCsvHelper.RefreshReferenceData/CardmarketFixtureGenerator.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using MtgCsvHelper;
+using MtgCsvHelper.Models;
 using MtgCsvHelper.Services;
 
 namespace MtgCsvHelper.RefreshReferenceData;
@@ -32,17 +33,16 @@ internal static class CardmarketFixtureGenerator
 
 	// Cardmarket condition values in the "Manage Stock" CSV. Natural ordering of the REST API's
 	// string codes (MT/NM/EX/GD/LP/PL/PO); see SITE_BEHAVIOR.md > Cardmarket for verification.
-	// Kept explicit (rather than relying on CardCondition.Id matching by coincidence) so the
-	// generator survives any future renumbering of the enum.
-	static readonly Dictionary<string, string> ConditionToId = new()
+	// Kept explicit (rather than casting the enum's numeric value) so the generator survives any future renumbering.
+	static readonly Dictionary<CardCondition, string> ConditionToId = new()
 	{
-		["Mint"] = "1",
-		["NearMint"] = "2",
-		["Excellent"] = "3",
-		["Good"] = "4",
-		["LightlyPlayed"] = "5",
-		["Played"] = "6",
-		["Poor"] = "7",
+		[CardCondition.Mint] = "1",
+		[CardCondition.NearMint] = "2",
+		[CardCondition.Excellent] = "3",
+		[CardCondition.Good] = "4",
+		[CardCondition.LightlyPlayed] = "5",
+		[CardCondition.Played] = "6",
+		[CardCondition.Poor] = "7",
 	};
 
 	public static async Task RunAsync()
@@ -98,9 +98,9 @@ internal static class CardmarketFixtureGenerator
 				continue;
 			}
 
-			if (!ConditionToId.TryGetValue(card.Condition.Name, out var condition))
+			if (!ConditionToId.TryGetValue(card.Condition, out var condition))
 			{
-				Console.WriteLine($"  skip: unmapped condition '{card.Condition.Name}' for {card.Printing.Name} ({setCode} #{collectorNumber})");
+				Console.WriteLine($"  skip: unmapped condition '{card.Condition}' for {card.Printing.Name} ({setCode} #{collectorNumber})");
 				skipped++;
 				continue;
 			}


### PR DESCRIPTION
- **Rarity stats** (item 2): the issue's "data is available, just needs wiring" premise was wrong — the bundle had no rarity field. Added one: `CardRarity` enum (Scryfall's documented closed set, incl. `special` = timeshifted/Masterpieces and `bonus` = VMA Power Nine), converted at the Scryfall boundary with `Unknown` fallback. `PhysicalMtgCard` gets its own typed `Rarity` (ScryfallApi's `Card.Rarity` is a string we cannot retype); backfilled by `CatalogValidator`/`CardmarketIdEnricher` via row replacement (`PerCardEnricher` now passes rows by `ref`). `GenerateSummary` prints the per-rarity breakdown in canonical order.
- **CLI parse errors** (item 3): exit 1 on bad arguments, 0 for `--help`/`--version`; usage printing was already handled by `CommandLineParser`.
- **Moxfield token prefix** (item 1): TODO was stale — the `EncodeToken` mechanism it asked for already exists one line below. Whether MOXFIELD should enable that flag is a site-behavior question; noted on the issue rather than guessed in config.
- Drive-by: adapted the tools project to the `CardCondition` enum refactor (not in the slnx, so its breakage was invisible to solution builds).

Bundle regenerated: 114,682 printings, 11.1 MB gzipped. CI regenerates via cache-key miss (`ReferenceCard.cs`/`ScryfallCardJson.cs` are hashed).

Closes #71