### PR TITLE
Accept exporter-decorated names that extend the canonical printing name (#93)

### DIFF
--- a/MtgCsvHelper.Tests/CatalogValidatorTests.cs
+++ b/MtgCsvHelper.Tests/CatalogValidatorTests.cs
@@ -65,6 +65,19 @@ public class CatalogValidatorTests(CatalogFixture fixture)
 		kept.Should().ContainSingle().Which.Card.Printing.Name.Should().Be(canonical);
 	}
 
+	// Real Dragon Shield decorations: "Morph Creature" (TKTK #11) and "Beast Token (4/4)" (TMH2 #9; " Token" is stripped before validation).
+	[Theory]
+	[InlineData("TKTK", "11", " Creature")]
+	[InlineData("TMH2", "9", " (4/4)")]
+	public async Task DecoratedName_ExtendingCanonical_IsAcceptedAndCanonicalized(string set, string number, string decoration)
+	{
+		var canonical = fixture.Catalog.FindBySetAndCollectorNumber(set, number)!.Name;
+		var (kept, issues) = await Validate(Row(canonical + decoration, set, number));
+
+		issues.Should().BeEmpty();
+		kept.Should().ContainSingle().Which.Card.Printing.Name.Should().Be(canonical);
+	}
+
 	[Fact]
 	public async Task ValidatedRow_GetsRarityBackfilledFromCatalog()
 	{

--- a/MtgCsvHelper/Enrichment/CatalogValidator.cs
+++ b/MtgCsvHelper/Enrichment/CatalogValidator.cs
@@ -34,14 +34,14 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 
 		if (!EqualsNormalized(p.Name, match.Name))
 		{
-			if (!EqualsNormalized(FrontFace(p.Name), FrontFace(match.Name)))
+			if (!EqualsNormalized(FrontFace(p.Name), FrontFace(match.Name)) && !ExtendsCanonicalName(p.Name, match.Name))
 			{
 				issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
 					$"Name '{p.Name}' does not match printing at {p.Set} #{p.CollectorNumber} ('{match.Name}')",
 					CardName: p.Name, RawContent: row.RawContent));
 				return false;
 			}
-			// (Set, #) already pins the printing; adopt its canonical name for a short or shared-front-face import.
+			// (Set, #) already pins the printing; adopt its canonical name for a short, shared-front-face, or decorated import.
 			p.Name = match.Name;
 		}
 
@@ -60,6 +60,10 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 
 	// Front face of a DFC name ("A // B" → "A"); a name without " // " is its own front face.
 	static string FrontFace(string name) => name.Split(" // ")[0];
+
+	// Exporter decorations ("Beast Token (4/4)", "Morph Creature") merely extend the canonical name; the name check stays a corruption guard.
+	static bool ExtendsCanonicalName(string imported, string canonical) =>
+		StripDiacritics(imported).StartsWith(StripDiacritics(canonical) + " ", StringComparison.OrdinalIgnoreCase);
 
 	// Compares with Unicode diacritic stripping (NFD + remove combining marks). TCGPlayer and a
 	// few other sites normalize "Lim-Dûl's Vault" → "Lim-Dul's Vault" on export; Scryfall keeps the

--- a/MtgCsvHelper/Resources/SampleCsvs/Tests/dragonshield-tokens-reference-collection.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Tests/dragonshield-tokens-reference-collection.csv
@@ -1,0 +1,6 @@
+"sep=,"
+Folder Name,Quantity,Trade Quantity,Card Name,Set Code,Set Name,Card Number,Condition,Printing,Language,Price Bought,Date Bought,AVG,LOW,TREND
+Other,1,0,Beast Token (4/4),TMH2,Modern Horizons 2 Tokens,9,NearMint,Normal,German,0.04,2022-02-21,0.02,0.01,0.09
+Other,1,0,Bird Token,TDMU,Dominaria United Tokens,2,NearMint,Normal,German,0.07,2022-09-16,0.02,0.01,0.09
+Other,1,0,Clue Token,TMH2,Modern Horizons 2 Tokens,15,NearMint,Normal,German,0.02,2022-02-21,0.09,0.01,0.13
+Other,1,0,Morph Creature,TKTK,Khans of Tarkir Tokens,11,NearMint,Normal,English,0.10,2022-02-14,0.02,0.01,0.04


### PR DESCRIPTION
`Beast Token (4/4)` and `Morph Creature` (verbatim rows from a real Dragon Shield export) errored with `Name 'X' does not match printing` even though `(Set, Collector#)` pinned the printing unambiguously. The validator now accepts an imported name that extends the canonical one with a space-anchored suffix and canonicalizes it — the same treatment short names and shared front faces already get. Corruption detection is preserved: a *different* name at a valid `(set, #)` still errors; the rule only fires when the canonical name is a word-boundary prefix of the import.

This covers both decoration styles from the issue with one rule — no per-format alias map needed. Live Moxfield verification (see #71) confirmed targets want the plain Scryfall name, so canonicalize-on-read is the correct direction.

New auto-discovered fixture `dragonshield-tokens-reference-collection.csv` (4 real rows: 2 previously failing, 2 control) asserts all rows parse error-free.

Closes #93