### PR TITLE
Reject unmapped condition strings instead of adding aliases (#69)

### DIFF
--- a/MtgCsvHelper.Tests/CardConditionConverterTests.cs
+++ b/MtgCsvHelper.Tests/CardConditionConverterTests.cs
@@ -69,4 +69,17 @@ public class CardConditionConverterTests : BaseTest
 
 		output.Should().Be("Mint", "formats with a distinct Mint tier keep the original mapping");
 	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData(null)]
+	public void ReadBlank_ResolvesToUnknown(string? text)
+	{
+		var converter = ConverterFor(mint: "Mint", nearMint: "Near Mint", excellent: null);
+
+		var result = converter.ConvertFromString(text, row: null!, memberMapData: null!) as CardCondition?;
+
+		result.Should().Be(CardCondition.Unknown, "a blank cell carries no condition info and is not a vocabulary error");
+	}
 }

--- a/MtgCsvHelper.Tests/FaultToleranceTests.cs
+++ b/MtgCsvHelper.Tests/FaultToleranceTests.cs
@@ -123,6 +123,20 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 	}
 
 	[Fact]
+	public void UnrecognizedCondition_RaisesError_RowDropped()
+	{
+		// "Pristine" is not in any format's condition vocabulary.
+		var csv = MoxHeader + "\n"
+			+ "1,Lightning Bolt,M11,149,,Pristine,English,\n";
+
+		var result = Handler().ParseCollectionCsv(CsvStream(csv));
+
+		result.Collection.Cards.Should().BeEmpty();
+		result.ErrorCount.Should().Be(1);
+		result.Issues[0].Reason.Should().Contain("Pristine").And.Contain("Condition");
+	}
+
+	[Fact]
 	public void NonSeekableStream_ThrowsArgumentExceptionEarly()
 	{
 		// GZipStream is the canonical non-seekable stream; the guard must fire before any read.

--- a/MtgCsvHelper/Converters/CardConditionConverter.cs
+++ b/MtgCsvHelper/Converters/CardConditionConverter.cs
@@ -1,4 +1,4 @@
-﻿using CsvHelper.Configuration;
+using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
 
 namespace MtgCsvHelper.Converters;
@@ -9,46 +9,44 @@ public class CardConditionConverter(ConditionConfiguration configuration) : ITyp
 
 	public object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
 	{
-		// TODO: tighten to reject unmapped values once appsettings supports per-enum aliases —
-		// real Moxfield exports use both "Near Mint" (binder export) and "NM" (collection export).
-		//
+		// Blank means the export carries no condition info — not a vocabulary error.
+		if (string.IsNullOrWhiteSpace(text)) { return CardCondition.Unknown; }
+
 		// Duplicate-string collisions are handled at the config level: formats whose Mint or
 		// Excellent collapses to the same string as NearMint declare those fields as `null` in
 		// appsettings.json, so only the NearMint arm matches and switch order is irrelevant.
 		// See CardConditionConverterTests.AmbiguousString_ResolvesToNearMint for the invariant.
 #pragma warning disable format
-			return text switch
-			{
-				_ when text.MatchesConfig(_conditionConfig.Mint)			=> CardCondition.Mint,
-				_ when text.MatchesConfig(_conditionConfig.NearMint)		=> CardCondition.NearMint,
-				_ when text.MatchesConfig(_conditionConfig.Excellent)		=> CardCondition.Excellent,
-				_ when text.MatchesConfig(_conditionConfig.Good)			=> CardCondition.Good,
-				_ when text.MatchesConfig(_conditionConfig.LightlyPlayed)	=> CardCondition.LightlyPlayed,
-				_ when text.MatchesConfig(_conditionConfig.Played)			=> CardCondition.Played,
-				_ when text.MatchesConfig(_conditionConfig.Poor)			=> CardCondition.Poor,
-				_															=> CardCondition.Unknown,
-			};
-
-		}
-
-		public string? ConvertToString(object? value, IWriterRow row, MemberMapData memberMapData)
+		return text switch
 		{
-			// Mint/Excellent fall back to NearMint when the format config declares no separate tier (null → NearMint).
-			return value is CardCondition condition
-				? condition switch
-				{
-					CardCondition.Mint          => _conditionConfig.Mint      ?? _conditionConfig.NearMint,
-					CardCondition.NearMint      => _conditionConfig.NearMint,
-					CardCondition.Excellent     => _conditionConfig.Excellent ?? _conditionConfig.NearMint,
-					CardCondition.Good          => _conditionConfig.Good,
-					CardCondition.LightlyPlayed => _conditionConfig.LightlyPlayed,
-					CardCondition.Played        => _conditionConfig.Played,
-					CardCondition.Poor          => _conditionConfig.Poor,
-					CardCondition.Unknown       => "",
-					_                           => "",
-				}
-				: "";
-		}
-#pragma warning restore format
+			_ when text.MatchesConfig(_conditionConfig.Mint)			=> CardCondition.Mint,
+			_ when text.MatchesConfig(_conditionConfig.NearMint)		=> CardCondition.NearMint,
+			_ when text.MatchesConfig(_conditionConfig.Excellent)		=> CardCondition.Excellent,
+			_ when text.MatchesConfig(_conditionConfig.Good)			=> CardCondition.Good,
+			_ when text.MatchesConfig(_conditionConfig.LightlyPlayed)	=> CardCondition.LightlyPlayed,
+			_ when text.MatchesConfig(_conditionConfig.Played)			=> CardCondition.Played,
+			_ when text.MatchesConfig(_conditionConfig.Poor)			=> CardCondition.Poor,
+			_ => throw new TypeConverterException(this, memberMapData, text, row.Context, $"Unrecognized Condition value '{text}'"),
+		};
 	}
 
+	public string? ConvertToString(object? value, IWriterRow row, MemberMapData memberMapData)
+	{
+		// Mint/Excellent fall back to NearMint when the format config declares no separate tier (null → NearMint).
+		return value is CardCondition condition
+			? condition switch
+			{
+				CardCondition.Mint          => _conditionConfig.Mint      ?? _conditionConfig.NearMint,
+				CardCondition.NearMint      => _conditionConfig.NearMint,
+				CardCondition.Excellent     => _conditionConfig.Excellent ?? _conditionConfig.NearMint,
+				CardCondition.Good          => _conditionConfig.Good,
+				CardCondition.LightlyPlayed => _conditionConfig.LightlyPlayed,
+				CardCondition.Played        => _conditionConfig.Played,
+				CardCondition.Poor          => _conditionConfig.Poor,
+				CardCondition.Unknown       => "",
+				_                           => "",
+			}
+			: "";
+	}
+#pragma warning restore format
+}

--- a/MtgCsvHelper/Resources/SampleCsvs/Tests/SITE_BEHAVIOR.md
+++ b/MtgCsvHelper/Resources/SampleCsvs/Tests/SITE_BEHAVIOR.md
@@ -19,7 +19,7 @@ Status: 41/41 rows round-trip cleanly (May 2026).
 
 **Schema:** binder and collection exports differ.
 - Binder export (the `moxfield_haves_*.csv` form): `Count,Tradelist Count,Name,Edition,Condition,Language,Foil,Tags,Last Modified,Collector Number,Alter,Proxy,Purchase Price`.
-- Collection export (`moxfield-collection.csv`): different column set including `Folder Name`, `Trade Quantity`, `Set Name`, `AVG`/`LOW`/`TREND`. Importantly: uses `Condition = NM` (abbreviation), not `Near Mint`. Our `appsettings.json` only encodes the binder form; this is why `CardConditionConverter` stays lenient (follow-up: per-enum aliases).
+- Historical note: the 2022-era `moxfield-collection.csv` fixture (deleted in the Dragon Shield 12-column rework) carried shorthand conditions (`NM`/`LP`/`D`) in a Moxfield-shaped header with Dragon Shield columns (`Folder Name`, `AVG`/`LOW`/`TREND`) — most likely Dragon Shield's Moxfield-format export, not Moxfield's own. Neither site emits that shorthand as of June 2026 (verified by fresh exports of both Moxfield forms); `CardConditionConverter` is strict and rejects it.
 - `Tradelist Count` is an independent value from `Count` — it tracks "how many of this row you're willing to trade", separate from "how many you own". Both are first-class columns.
 
 **Enriches on import:**

--- a/MtgCsvHelper/Resources/SampleCsvs/Tests/moxfield-conditions-reference-collection.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Tests/moxfield-conditions-reference-collection.csv
@@ -1,0 +1,7 @@
+"Count","Tradelist Count","Name","Edition","Condition","Language","Foil","Tags","Last Modified","Collector Number","Alter","Proxy","Purchase Price"
+"1","1","Lightning Bolt","m11","Mint","English","","","2026-05-15 13:51:43.373000","149","False","False","0.50"
+"1","1","Aarakocra Sneak","clb","Near Mint","Korean","","","2025-06-27 06:59:41.710000","54","False","False",""
+"1","1","Ambitious Farmhand // Seasoned Cathar","mid","Good (Lightly Played)","English","","","2023-10-01 10:02:06.313000","2","False","False","0.14"
+"1","1","Jadelight Ranger","rix","Heavily Played","German","","","2023-10-01 10:02:06.313000","136","False","False","0.83"
+"1","1","Lightning Bolt","m11","Played","English","","","2026-05-15 13:51:43.373000","149","False","False","0.20"
+"1","1","Lightning Bolt","m11","Damaged","English","","","2026-05-15 13:51:43.373000","149","False","False","0.10"


### PR DESCRIPTION
#69 proposed per-tier read aliases for a second, abbreviated Moxfield condition vocabulary. Verification killed the premise:

- Fresh exports of both current Moxfield forms (incl. a 7,389-row haves export covering **all six tiers**) spell conditions out with the configured primary strings.
- The shorthand's only source, the 2022-era `moxfield-collection.csv` (recovered from git history; deleted in `c70c3a1`), contained `NM`/`LP`/`D` — not the `NM/LP/MP/HP/DM` the issue claimed — inside a hybrid header (`Folder Name`, `AVG`/`LOW`/`TREND`) that is most likely **Dragon Shield's Moxfield-format export**, not Moxfield's own. Neither site emits that shorthand today.

So no alias mechanism. Instead, `CardConditionConverter` drops its leniency: a non-blank string outside the configured vocabulary raises a row error (matching `FinishConverter`/`LanguageConverter`); blank stays `Unknown`. The unreproducible legacy shape now fails loudly instead of silently importing every condition as `Unknown` — which is what the "lenient" path actually did.

New real fixture `moxfield-conditions-reference-collection.csv` (six verbatim rows from today's export, one per tier) pins the strictness claim. `SITE_BEHAVIOR.md`'s stale "stays lenient (follow-up: per-enum aliases)" note replaced with the historical record.

Closes #69
