### PR TITLE
Replace bool? Foil with a tri-state CardFinish enum (#68)

### DIFF
--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -356,9 +356,13 @@
 							}
 						</MudTd>
 						<MudTd DataLabel="Foil">
-							@if (card.Foil is true)
+							@if (card.Finish is CardFinish.Foil)
 							{
 								<MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Filled">F</MudChip>
+							}
+							else if (card.Finish is CardFinish.Etched)
+							{
+								<MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Filled">E</MudChip>
 							}
 						</MudTd>
 						<MudTd DataLabel="Condition">@(card.Condition == CardCondition.Unknown ? "" : card.Condition.ToString())</MudTd>

--- a/MtgCsvHelper.Tests/CardmarketTests.cs
+++ b/MtgCsvHelper.Tests/CardmarketTests.cs
@@ -40,9 +40,9 @@ public class CardmarketTests(CatalogFixture fixture, ITestOutputHelper output) :
 		var result = await Handler().ParseCollectionCsvAsync(SamplePath);
 		var byName = result.Collection.Cards.ToDictionary(c => c.Printing.Name);
 
-		byName["Master's Rebuke"].Foil.Should().Be(true);   // isFoil=1 in fixture
-		byName["Cliffgate"].Foil.Should().Be(true);         // isFoil=1 in fixture
-		byName["Putrid Leech"].Foil.Should().Be(false);     // isFoil empty in fixture
+		byName["Master's Rebuke"].Finish.Should().Be(CardFinish.Foil);   // isFoil=1 in fixture
+		byName["Cliffgate"].Finish.Should().Be(CardFinish.Foil);         // isFoil=1 in fixture
+		byName["Putrid Leech"].Finish.Should().Be(CardFinish.Normal);    // isFoil empty in fixture
 	}
 
 	[Fact]

--- a/MtgCsvHelper.Tests/FinishConverterTests.cs
+++ b/MtgCsvHelper.Tests/FinishConverterTests.cs
@@ -4,11 +4,14 @@ namespace MtgCsvHelper.Tests;
 
 public class FinishConverterTests
 {
-	// DragonShield's "Printing" column: Normal / Foil plus an open-ended set of variant treatments.
-	static readonly FinishConverter Converter = new(new FinishConfiguration("Printing", Foil: "Foil", Normal: "Normal", Etched: null));
+	// DragonShield's "Printing" column: Normal / Foil plus an open-ended set of variant treatments; no etched tier.
+	static readonly FinishConverter DragonShield = new(new FinishConfiguration("Printing", Foil: "Foil", Normal: "Normal", Etched: null));
+	// Manabox-style: a distinct etched string.
+	static readonly FinishConverter WithEtched = new(new FinishConfiguration("Foil", Foil: "foil", Normal: "normal", Etched: "etched"));
 
-	// The accept/normal branches never touch row or memberMapData; only the throw path does.
-	static object? Convert(string text) => Converter.ConvertFromString(text, null!, null!);
+	// The accept branches never touch row or memberMapData; only the throw path does.
+	static object? Read(FinishConverter c, string text) => c.ConvertFromString(text, null!, null!);
+	static string? Write(FinishConverter c, CardFinish f) => c.ConvertToString(f, null!, null!);
 
 	[Theory]
 	[InlineData("Foil")]
@@ -20,12 +23,29 @@ public class FinishConverterTests
 	[InlineData("Galaxy Foil")]
 	[InlineData("surge foil")]
 	public void VariantFoilTreatments_MapToFoil(string printing) =>
-		Convert(printing).Should().Be(true);
+		Read(DragonShield, printing).Should().Be(CardFinish.Foil);
 
 	[Theory]
 	[InlineData("Normal")]
 	[InlineData("")]
 	[InlineData("   ")]
-	public void NonFoilTreatments_MapToNonFoil(string printing) =>
-		Convert(printing).Should().Be(false);
+	public void NonFoilTreatments_MapToNormal(string printing) =>
+		Read(DragonShield, printing).Should().Be(CardFinish.Normal);
+
+	[Fact]
+	public void EtchedString_MapsToEtched_WhenFormatHasEtchedTier() =>
+		Read(WithEtched, "etched").Should().Be(CardFinish.Etched);
+
+	[Fact]
+	public void WriteEtched_WithEtchedTier_EmitsEtchedString() =>
+		Write(WithEtched, CardFinish.Etched).Should().Be("etched");
+
+	[Fact]
+	public void WriteEtched_WithoutEtchedTier_FallsBackToFoilString() =>
+		Write(DragonShield, CardFinish.Etched).Should().Be("Foil", "DragonShield has no etched tier; etched collapses to its Foil string");
+
+	[Fact]
+	public void WriteUnknown_EmitsEmptyCell() =>
+		// Empty string, NOT null: a null return makes CsvHelper drop the field and shift later columns.
+		Write(DragonShield, CardFinish.Unknown).Should().BeEmpty("a finish we never learned writes blank rather than asserting Normal");
 }

--- a/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
+++ b/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
@@ -35,6 +35,46 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 			: opts);
 	}
 
+	// Demonic Tutor CMM #509 has an etched printing.
+	[Theory]
+	[InlineData("MOXFIELD")]
+	[InlineData("MANABOX")]
+	[InlineData("TOPDECKED")]
+	[InlineData("ARCHIDEKT")]
+	public void EtchedFinish_RoundTripsThroughEtchedSupportingFormats(string format)
+	{
+		var handler = CreateHandler(format);
+		var etched = EtchedDemonicTutor();
+
+		string fileName = $"unittest-etched-{format}.csv";
+		handler.WriteCollectionCsv([etched], fileName);
+		var parsed = handler.ParseCollectionCsv(fileName).Collection.Cards;
+
+		parsed.Should().ContainSingle().Which.Finish.Should().Be(CardFinish.Etched);
+	}
+
+	[Fact]
+	public void EtchedFinish_CollapsesToFoil_WhenFormatHasNoEtchedTier()
+	{
+		// DragonShield configures no etched string; etched must degrade to foil, not error or vanish.
+		var handler = CreateHandler("DRAGONSHIELD");
+
+		string fileName = "unittest-etched-DRAGONSHIELD.csv";
+		handler.WriteCollectionCsv([EtchedDemonicTutor()], fileName);
+		var parsed = handler.ParseCollectionCsv(fileName).Collection.Cards;
+
+		parsed.Should().ContainSingle().Which.Finish.Should().Be(CardFinish.Foil);
+	}
+
+	static PhysicalMtgCard EtchedDemonicTutor() => new()
+	{
+		Count = 1,
+		Condition = CardCondition.NearMint,
+		Finish = CardFinish.Etched,
+		Language = "en",
+		Printing = new Card { Name = "Demonic Tutor", Set = "CMM", SetName = "Commander Masters", CollectorNumber = "509" },
+	};
+
 	[Theory]
 	[InlineData($"{TESTS_FOLDER}/dragonshield-field-fidelity.csv", "DRAGONSHIELD", "USD")]
 	[InlineData($"{TESTS_FOLDER}/moxfield-field-fidelity.csv", "MOXFIELD", "EUR")]
@@ -165,7 +205,7 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 		{
 			Count = 1,
 			Condition = CardCondition.Mint,
-			Foil = false,
+			Finish = CardFinish.Normal,
 			Printing = new Card
 			{
 				Name = "Ambitious Farmhand // Seasoned Cathar",
@@ -179,12 +219,12 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 
         var card2 = card1 with { Language = "zht" };
 
-        // Card3 verifies Count, Foil, Language, PriceBought
+        // Card3 verifies Count, Finish, Language, PriceBought
         var card3 = card1 with
 		{
 			Count = 2,
 			Condition = CardCondition.NearMint,
-			Foil = true,
+			Finish = CardFinish.Foil,
 			Language = "de",
 			PriceBought = new Money(0.20m, currency),
 		};
@@ -199,7 +239,7 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 		{
 			Count = 1,
 			Condition = CardCondition.NearMint,
-			Foil = false,
+			Finish = CardFinish.Normal,
 			Printing = new Card
 			{
 				Name = "Clue",
@@ -216,7 +256,7 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 		{
 			Count = 1,
 			Condition = CardCondition.NearMint,
-			Foil = false,
+			Finish = CardFinish.Normal,
 			Printing = new Card
 			{
 				Name = "Food",

--- a/MtgCsvHelper.Tests/TcgplayerWriteTests.cs
+++ b/MtgCsvHelper.Tests/TcgplayerWriteTests.cs
@@ -10,7 +10,7 @@ public class TcgplayerWriteTests(CatalogFixture fixture, ITestOutputHelper outpu
 	{
 		Count = 1,
 		Condition = CardCondition.NearMint,
-		Foil = false,
+		Finish = CardFinish.Normal,
 		Language = "en",
 		Printing = new Card { Name = name, Set = set, SetName = "", CollectorNumber = collectorNumber },
 	};

--- a/MtgCsvHelper/Converters/FinishConverter.cs
+++ b/MtgCsvHelper/Converters/FinishConverter.cs
@@ -1,4 +1,4 @@
-﻿using CsvHelper.Configuration;
+using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
 
 namespace MtgCsvHelper.Converters;
@@ -9,19 +9,25 @@ public class FinishConverter(FinishConfiguration configuration) : ITypeConverter
 
 	public object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
 	{
-		if (string.IsNullOrWhiteSpace(text)) { return false; }
-		if (text.MatchesConfig(_finishConfig.Foil)) { return true; }
-		// Etched collapses to foil=true: the current `bool? Foil` model can't represent it.
-		// Tri-state Foil enum is the planned follow-up; see ConvertToString for the matching write-side data loss.
-		if (text.MatchesConfig(_finishConfig.Etched)) { return true; }
-		if (text.MatchesConfig(_finishConfig.Normal)) { return false; }
-		// Variant treatments (Surge Foil, Step and Compleat Foil, …) all carry the word "Foil".
-		if (text.Contains("foil", StringComparison.OrdinalIgnoreCase)) { return true; }
+		// A blank cell is the format's "not foil" — Moxfield even configures Normal as the empty string.
+		if (string.IsNullOrWhiteSpace(text)) { return CardFinish.Normal; }
+		if (text.MatchesConfig(_finishConfig.Etched)) { return CardFinish.Etched; }
+		if (text.MatchesConfig(_finishConfig.Foil)) { return CardFinish.Foil; }
+		if (text.MatchesConfig(_finishConfig.Normal)) { return CardFinish.Normal; }
+		// Variant treatments (Surge Foil, Rainbow Foil, …) are promo_types layered on a foil finish.
+		if (text.Contains("foil", StringComparison.OrdinalIgnoreCase)) { return CardFinish.Foil; }
 
 		throw new TypeConverterException(this, memberMapData, text, row.Context, $"Unrecognized Foil value '{text}'");
 	}
 
-	// An etched card stored as foil=true is written here as the Foil string — silent promotion
-	// from etched to foil on round-trip. Resolved when Foil becomes a tri-state enum (see ConvertFromString).
-	public string? ConvertToString(object? value, IWriterRow row, MemberMapData memberMapData) => value is true ? _finishConfig.Foil : _finishConfig.Normal;
+	// Etched falls back to the Foil string when the format has no etched tier (Deckbox/Cardmarket collapse it on storage anyway).
+	public string? ConvertToString(object? value, IWriterRow row, MemberMapData memberMapData) =>
+		value switch
+		{
+			CardFinish.Etched => _finishConfig.Etched ?? _finishConfig.Foil,
+			CardFinish.Foil   => _finishConfig.Foil,
+			CardFinish.Normal => _finishConfig.Normal,
+			// "" not null: a null return makes CsvHelper drop the field and shift every later column.
+			_                 => "",
+		};
 }

--- a/MtgCsvHelper/Enrichment/CatalogValidator.cs
+++ b/MtgCsvHelper/Enrichment/CatalogValidator.cs
@@ -5,7 +5,7 @@ namespace MtgCsvHelper.Enrichment;
 
 /// <summary>
 /// The one validator in the post-parse pipeline. Drops rows whose (Set, CollectorNumber)
-/// doesn't resolve, whose Name doesn't match the resolved printing, or whose Foil flag
+/// doesn't resolve, whose Name doesn't match the resolved printing, or whose Finish
 /// claims an unsupported finish. Named "Validator" rather than "Enricher" because it mainly
 /// checks-and-drops; its only mutations are the issues collection, canonicalizing the
 /// name of a short-named or front-face-ambiguous double-faced card to the resolved printing,
@@ -45,7 +45,7 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 			p.Name = match.Name;
 		}
 
-		if (row.Card.Foil is true && !HasFoilFinish(match.Finishes))
+		if ((row.Card.Finish is CardFinish.Foil or CardFinish.Etched) && !HasFoilFinish(match.Finishes))
 		{
 			issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
 				$"Printing {p.Set} #{p.CollectorNumber} was not released in foil",

--- a/MtgCsvHelper/Maps/CardKingdomWriteMap.cs
+++ b/MtgCsvHelper/Maps/CardKingdomWriteMap.cs
@@ -14,7 +14,7 @@ public class CardKingdomWriteMap : ClassMap<PhysicalMtgCard>
 
 		Map(card => card.Printing.Name).TypeConverter(new CardNameConverter(columnConfig.CardName, catalog)).Name(columnConfig.CardName.HeaderName).Index(0);
 		if (columnConfig.SetName is not null) { Map(card => card.Printing.SetName).TypeConverter<UpperCaseConverter>().Name(columnConfig.SetName).Index(1); }
-		Map(card => card.Foil).TypeConverter(new FinishConverter(columnConfig.Finish)).Name(columnConfig.Finish.HeaderName).Index(2);
+		Map(card => card.Finish).TypeConverter(new FinishConverter(columnConfig.Finish)).Name(columnConfig.Finish.HeaderName).Index(2);
 		Map(card => card.Count).Name(columnConfig.Quantity).Index(3);
 	}
 }

--- a/MtgCsvHelper/Maps/PhysicalCardMap.cs
+++ b/MtgCsvHelper/Maps/PhysicalCardMap.cs
@@ -44,7 +44,7 @@ public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 		MapOptional(c => c.Printing.CollectorNumber, cfg.SetNumber)?.TypeConverter<CollectorNumberConverter>().Index(6);
 
 		MapOptional(c => c.Condition, cfg.Condition, c => new CardConditionConverter(c))?.Index(7);
-		MapOptional(c => c.Foil, cfg.Finish, c => new FinishConverter(c))?.Index(8);
+		MapOptional(c => c.Finish, cfg.Finish, c => new FinishConverter(c))?.Index(8);
 		MapOptional(c => c.Language, cfg.Language, c => new LanguageConverter(c))?.Index(9);
 		MapOptional(c => c.PriceBought, cfg.PriceBought, c => new PriceConverter(c))?.Index(10);
 

--- a/MtgCsvHelper/Models/CardFinish.cs
+++ b/MtgCsvHelper/Models/CardFinish.cs
@@ -1,0 +1,14 @@
+namespace MtgCsvHelper.Models;
+
+/// <summary>
+/// Physical print finish, matching Scryfall's closed <c>finishes</c> vocabulary. A copy is
+/// exactly one of these. Foiling <em>treatments</em> (Rainbow Foil, Surge Foil, …) are a
+/// separate Scryfall axis (<c>promo_types</c>) and collapse to <see cref="Foil"/> here.
+/// </summary>
+public enum CardFinish
+{
+	Unknown,
+	Normal,
+	Foil,
+	Etched,
+}

--- a/MtgCsvHelper/Models/CollectionSummary.cs
+++ b/MtgCsvHelper/Models/CollectionSummary.cs
@@ -7,7 +7,7 @@ namespace MtgCsvHelper.Models;
 /// </summary>
 /// <param name="TotalCount">Sum of <see cref="PhysicalMtgCard.Count"/> across all cards.</param>
 /// <param name="UniqueCount">Number of distinct rows (each row is one printing).</param>
-/// <param name="FoilCount">Sum of <see cref="PhysicalMtgCard.Count"/> for rows where <see cref="PhysicalMtgCard.Foil"/> is true.</param>
+/// <param name="FoilCount">Sum of <see cref="PhysicalMtgCard.Count"/> for rows whose <see cref="PhysicalMtgCard.Finish"/> is Foil or Etched.</param>
 /// <param name="TotalValue">Sum of <c>PriceBought × Count</c> across all priced rows, or null if no prices or currencies are mixed.</param>
 /// <param name="MostExpensive">The row with the highest <em>unit</em> price (regardless of Count), or null if no prices.</param>
 public sealed record CollectionSummary(
@@ -35,7 +35,7 @@ public sealed record CollectionSummary(
 		return new CollectionSummary(
 			TotalCount: cards.Sum(c => c.Count),
 			UniqueCount: cards.Count,
-			FoilCount: cards.Where(c => c.Foil is true).Sum(c => c.Count),
+			FoilCount: cards.Where(c => c.Finish is CardFinish.Foil or CardFinish.Etched).Sum(c => c.Count),
 			TotalValue: totalValue,
 			MostExpensive: priced.OrderByDescending(c => c.PriceBought!.Value).FirstOrDefault());
 	}

--- a/MtgCsvHelper/Models/PhysicalMtgCard.cs
+++ b/MtgCsvHelper/Models/PhysicalMtgCard.cs
@@ -3,7 +3,7 @@
 namespace MtgCsvHelper.Models;
 
 // Property order follows PhysicalCardMap's CSV index order (Folder, Count, TradeQuantity,
-// Printing (Name/Set/SetName/CollectorNumber), Condition, Foil, Language, PriceBought,
+// Printing (Name/Set/SetName/CollectorNumber), Condition, Finish, Language, PriceBought,
 // DateBought). TradeListed has no CSV column today and sits at the end.
 public record PhysicalMtgCard
 {
@@ -19,7 +19,7 @@ public record PhysicalMtgCard
 
 	public CardCondition Condition { get; init; } = CardCondition.Unknown;
 
-	public bool? Foil { get; init; }
+	public CardFinish Finish { get; init; } = CardFinish.Unknown;
 
 	// Encodes 2-letter ISO language code (queryable via CultureInfo)
 	public string? Language { get; init; }

--- a/tools/MtgCsvHelper.RefreshReferenceData/CardmarketFixtureGenerator.cs
+++ b/tools/MtgCsvHelper.RefreshReferenceData/CardmarketFixtureGenerator.cs
@@ -104,7 +104,7 @@ internal static class CardmarketFixtureGenerator
 				skipped++;
 				continue;
 			}
-			var isFoil = card.Foil == true ? "1" : "";
+			var isFoil = card.Finish is CardFinish.Foil or CardFinish.Etched ? "1" : "";
 			var groupCount = card.Count.ToString(CultureInfo.InvariantCulture);
 			var price = card.PriceBought is { Value: > 0 } money
 				? money.Value.ToString("0.00", CultureInfo.InvariantCulture)


### PR DESCRIPTION
Scryfall's `finishes` is a closed three-value set — verified across all 114,682 bundle printings, every one a subset of `{nonfoil, foil, etched}`. The old `bool? Foil` collapsed `etched` into `foil` and lost it on round-trip. `PhysicalMtgCard.Foil` → `CardFinish {Unknown, Normal, Foil, Etched}`.

- **Read:** configured Normal/Foil/Etched strings → matching enum value. Variant foiling *treatments* (Rainbow Foil, Surge Foil — Scryfall `promo_types`, a separate axis) still collapse to `Foil`, as before. Scope held to the finish axis per the issue; treatment preservation is tracked separately in #115.
- **Write:** `Etched` falls back to the Foil string where a format has no etched tier (Deckbox/Cardmarket collapse it anyway). `Unknown` writes `""` — **not `null`**, which (instrumented) makes CsvHelper drop the field and shift every later column, corrupting the row.
- **Etched now round-trips losslessly** through the four etched-capable formats (Moxfield/Manabox/TopDecked/Archidekt); a dedicated test asserts it, plus a collapse-to-foil test for DragonShield. The Blazor table shows a distinct `E` chip.

`CatalogValidator`'s foil-on-nonfoil guard and `CollectionSummary`'s foil count both treat Foil and Etched as foil-family.

Closes #68
