### PR TITLE
Resolve stale (set,#) coordinates by name rewrite (#92)

### DIFF
--- a/MtgCsvHelper.Tests/CatalogValidatorTests.cs
+++ b/MtgCsvHelper.Tests/CatalogValidatorTests.cs
@@ -98,4 +98,25 @@ public class CatalogValidatorTests(CatalogFixture fixture)
 		kept.Should().BeEmpty();
 		issues.Should().ContainSingle().Which.Severity.Should().Be(IssueSeverity.Error);
 	}
+
+	// MB1 was folded into The List (MB1 #62 → plst #AER-13), so the row is rewritten to the successor printing, not dropped.
+	[Fact]
+	public async Task StaleSetCode_RewrittenToSuccessorPrinting_WithWarning()
+	{
+		var (kept, issues) = await Validate(Row("Countless Gears Renegade", "MB1", "62"));
+
+		var printing = kept.Should().ContainSingle().Which.Card.Printing;
+		printing.Set.Should().Be("PLST", because: "MB1 is a retired alias for The List");
+		printing.CollectorNumber.Should().Be("AER-13");
+		issues.Should().ContainSingle().Which.Severity.Should().Be(IssueSeverity.Warning);
+	}
+
+	[Fact]
+	public async Task UnresolvableBySetNumberAndName_StillErrors()
+	{
+		var (kept, issues) = await Validate(Row("Nonexistent Phantasm Qzx", "MB1", "62"));
+
+		kept.Should().BeEmpty();
+		issues.Should().ContainSingle().Which.Severity.Should().Be(IssueSeverity.Error);
+	}
 }

--- a/MtgCsvHelper.Tests/FaultToleranceTests.cs
+++ b/MtgCsvHelper.Tests/FaultToleranceTests.cs
@@ -13,22 +13,20 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 	MtgCardCsvHandler Handler(string format = "MOXFIELD") => new(_catalog, _resolver, _config, format);
 
 	[Fact]
-	public void UnknownSetCode_RaisesError_RowDropped()
+	public void UnknownSetCode_WithValidName_RewrittenByName()
 	{
-		// "FAKESET" is not a real Scryfall set code — EnrichSetInfo warns it can't backfill
-		// the set name, then the catalog-validation step errors out because (FAKESET, 149)
-		// doesn't resolve to any printing. Net effect: 1 warning + 1 error, card dropped.
+		// "FAKESET" doesn't resolve by coordinate; the valid name "Lightning Bolt" rewrites it to a real printing (Warning), not dropped.
 		var csv = MoxHeader + "\n"
 			+ "1,Lightning Bolt,FAKESET,149,,Near Mint,English,\n";
 
 		var result = Handler().ParseCollectionCsv(CsvStream(csv));
 
-		result.Collection.Cards.Should().BeEmpty();
-		result.ErrorCount.Should().Be(1);
-		result.Issues.Should().Contain(i => i.Severity == IssueSeverity.Warning && i.Reason.Contains("FAKESET"));
-		result.Issues.Should().Contain(i => i.Severity == IssueSeverity.Error && i.Reason.Contains("FAKESET"));
-		// RawContent must be threaded from the parse loop through both the SetInfoEnricher
-		// warning and the CatalogValidator error so the UI can show the offending row.
+		result.ErrorCount.Should().Be(0);
+		var printing = result.Collection.Cards.Should().ContainSingle().Which.Printing;
+		printing.Name.Should().Be("Lightning Bolt");
+		printing.Set.Should().NotBe("FAKESET", because: "the stale set code is rewritten to a real printing");
+		result.Issues.Should().Contain(i => i.Severity == IssueSeverity.Warning);
+		// RawContent must be threaded from the parse loop through the issues so the UI can show the row.
 		result.Issues.Should().AllSatisfy(i => i.RawContent.Should().Contain("Lightning Bolt").And.Contain("FAKESET"));
 	}
 
@@ -76,18 +74,19 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 	}
 
 	[Fact]
-	public void SetAndCollectorNotInCatalog_RaisesError_RowDropped()
+	public void SetAndCollectorNotInCatalog_WithValidName_RewrittenByName()
 	{
-		// M11 has 249 cards. #9999 doesn't exist.
+		// M11 #9999 doesn't exist; the valid name "Lightning Bolt" rewrites it to a real printing (Warning), not dropped.
 		var csv = MoxHeader + "\n"
 			+ "1,Lightning Bolt,M11,9999,,Near Mint,English,\n";
 
 		var result = Handler().ParseCollectionCsv(CsvStream(csv));
 
-		result.Collection.Cards.Should().BeEmpty();
-		result.ErrorCount.Should().Be(1);
-		result.Issues[0].Reason.Should().Contain("No printing").And.Contain("M11").And.Contain("9999");
-		result.Issues[0].RawContent.Should().Contain("9999");
+		result.ErrorCount.Should().Be(0);
+		result.Collection.Cards.Should().ContainSingle().Which.Printing.Name.Should().Be("Lightning Bolt");
+		var warning = result.Issues.Should().ContainSingle(i => i.Severity == IssueSeverity.Warning).Which;
+		warning.Reason.Should().Contain("No printing").And.Contain("M11").And.Contain("9999");
+		warning.RawContent.Should().Contain("9999");
 	}
 
 	[Fact]

--- a/MtgCsvHelper.Tests/TestCollectionFixtureTests.cs
+++ b/MtgCsvHelper.Tests/TestCollectionFixtureTests.cs
@@ -56,13 +56,13 @@ public class TestCollectionFixtureTests(CatalogFixture fixture, ITestOutputHelpe
 	/// <summary>
 	/// Fixtures with documented site-specific divergence from Scryfall. The listed error count is
 	/// expected; the mixed-assertion still forbids silent drops (cards + errors == data rows).
-	/// Deckbox's remaining errors are collector-number divergences in legacy sets — it numbers old
-	/// reprint products (The List, Alpha, Alliances, Ultimate Box Toppers) differently from Scryfall;
-	/// its set-name and edition-code aliasing (EX_NN tokens, PP_NEO promos, 1E/AL/PLIST codes) is handled.
+	/// Most of Deckbox's legacy-set reprints (The List, Alliances, Box Toppers) now recover via the
+	/// stale-coordinate name rewrite. The one remaining error is an Alpha collector-number divergence:
+	/// Deckbox's Alpha #13 aliases to LEA #13, which is a different card, so the name can't match the coordinate.
 	/// </summary>
 	static readonly IReadOnlyDictionary<string, (int ExpectedErrors, string Divergence)> KnownDivergence = new Dictionary<string, (int, string)>
 	{
-		["deckbox-real-export.csv"] = (ExpectedErrors: 5, Divergence: "legacy-set collector-number divergences"),
+		["deckbox-real-export.csv"] = (ExpectedErrors: 1, Divergence: "legacy-set collector-number divergences"),
 	};
 
 	[Theory]

--- a/MtgCsvHelper/Enrichment/CatalogValidator.cs
+++ b/MtgCsvHelper/Enrichment/CatalogValidator.cs
@@ -26,10 +26,27 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 		var match = catalog.FindBySetAndCollectorNumber(p.Set, p.CollectorNumber);
 		if (match is null)
 		{
-			issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
-				$"No printing at {p.Set} #{p.CollectorNumber} in Scryfall data",
+			// A stale (set, #) coordinate (e.g. a retired set code): rewrite to the current printing by name so the output stays importable.
+			var resolved = catalog.ResolveStalePrinting(p.Name, p.Set);
+			if (resolved is null)
+			{
+				issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
+					$"No printing at {p.Set} #{p.CollectorNumber} in Scryfall data",
+					CardName: p.Name, RawContent: row.RawContent));
+				return false;
+			}
+
+			issues.Add(new ImportIssue(IssueSeverity.Warning, row.RowNumber,
+				$"No printing at {p.Set} #{p.CollectorNumber} in Scryfall data; rewritten to {resolved.Set} #{resolved.CollectorNumber}",
 				CardName: p.Name, RawContent: row.RawContent));
-			return false;
+
+			p.Name = resolved.Name;
+			p.Set = resolved.Set;
+			p.SetName = resolved.SetName;
+			p.CollectorNumber = resolved.CollectorNumber;
+			row = row with { Card = row.Card with { Rarity = resolved.Rarity } };
+
+			return true;
 		}
 
 		if (!EqualsNormalized(p.Name, match.Name))

--- a/MtgCsvHelper/IReferenceCardCatalog.cs
+++ b/MtgCsvHelper/IReferenceCardCatalog.cs
@@ -17,6 +17,14 @@ public interface IReferenceCardCatalog
 	ReferenceCard? FindBySetAndCollectorNumber(string setCode, string collectorNumber);
 
 	/// <summary>
+	/// Resolves a card whose (set, collector#) coordinate no longer exists, returning the printing
+	/// to rewrite it to so the output stays importable. Prefers the successor set a retired code now
+	/// aliases to (e.g. Mystery Booster MB1 → The List), falling back to any printing of the name.
+	/// Null if the name isn't in the catalog at all.
+	/// </summary>
+	ReferenceCard? ResolveStalePrinting(string name, string staleSetCode);
+
+	/// <summary>
 	/// Distinct sets present in the catalog. Keys are uppercase set codes (e.g. "ISD"),
 	/// values are mixed-case set names as Scryfall delivers them (e.g. "Innistrad").
 	/// </summary>

--- a/MtgCsvHelper/ReferenceCardCatalog.cs
+++ b/MtgCsvHelper/ReferenceCardCatalog.cs
@@ -27,6 +27,7 @@ public sealed class ReferenceCardCatalog : IReferenceCardCatalog
 	readonly Dictionary<Guid, ReferenceCard> _byId;
 	readonly Dictionary<int, ReferenceCard> _byCardmarketId;
 	readonly Dictionary<(string Set, string CollectorNumber), ReferenceCard> _bySetAndCollector;
+	readonly Dictionary<string, List<ReferenceCard>> _printingsByName;  // "Lightning Bolt" -> all its printings
 	readonly Dictionary<string, string> _sets;
 	readonly Dictionary<string, string> _setCodeByName;     // "Innistrad" -> "ISD"
 	readonly Dictionary<string, string> _setCodeByMtgoCode; // "MI" -> "MIR"
@@ -43,6 +44,7 @@ public sealed class ReferenceCardCatalog : IReferenceCardCatalog
 		_byId = new(cards.Count);
 		_byCardmarketId = [];
 		_bySetAndCollector = new(cards.Count);
+		_printingsByName = new(StringComparer.OrdinalIgnoreCase);
 		_sets = [];
 		_setCodeByName = new(StringComparer.OrdinalIgnoreCase);  // human-typed names: stay forgiving
 		_setCodeByMtgoCode = [];
@@ -59,6 +61,9 @@ public sealed class ReferenceCardCatalog : IReferenceCardCatalog
 			// First-write-wins on duplicate (set, collector_number); Scryfall keeps these unique
 			// per English printing in default_cards but TryAdd makes the intent explicit.
 			_bySetAndCollector.TryAdd((c.Set, c.CollectorNumber), c);
+			// All printings per name; the fallback when a (set, #) coordinate is stale (e.g. a retired set code).
+			if (!_printingsByName.TryGetValue(c.Name, out var printings)) { _printingsByName[c.Name] = printings = []; }
+			printings.Add(c);
 			_sets.TryAdd(c.Set, c.SetName);
 			_setCodeByName.TryAdd(c.SetName, c.Set);
 			if (!string.IsNullOrEmpty(c.MtgoCode)) { _setCodeByMtgoCode.TryAdd(c.MtgoCode, c.Set); }
@@ -92,6 +97,25 @@ public sealed class ReferenceCardCatalog : IReferenceCardCatalog
 	{
 		var canonical = Canonicalize(setCode);
 		return _bySetAndCollector.GetValueOrDefault((canonical, collectorNumber));
+	}
+
+	ReferenceCard? FindByName(string name) => _printingsByName.GetValueOrDefault(name)?.FirstOrDefault();
+
+	// Retired set codes Scryfall folded into a successor set (no per-card redirect); hand-curated, grows as exports surface them.
+	static readonly Dictionary<string, string> RetiredSetAliases = new(StringComparer.OrdinalIgnoreCase)
+	{
+		["MB1"] = "PLST",
+	};
+
+	public ReferenceCard? ResolveStalePrinting(string name, string staleSetCode)
+	{
+		if (RetiredSetAliases.TryGetValue(staleSetCode, out var successor)
+			&& _printingsByName.GetValueOrDefault(name)?.FirstOrDefault(c => c.Set == successor) is { } aliased)
+		{
+			return aliased;
+		}
+
+		return FindByName(name);
 	}
 
 	public IReadOnlyDictionary<string, string> GetSets() => _sets;


### PR DESCRIPTION
Closes #92 (for the `default_cards` bundle; foreign-language name matching stays with #103).

## Problem

Retired/renumbered set codes leave a `(set, collector#)` coordinate that resolves nowhere. Mystery Booster's `MB1` was folded into The List and the card renumbered (`MB1/62` → `plst/AER-13`) — Scryfall's live API even 404s `/cards/mb1/62`. `CatalogValidator` dropped these rows with an error, so real DragonShield / Manabox collections lost their Mystery Booster cards on conversion.

## Fix

On a `(set,#)` miss, resolve the card by name and **rewrite** it to the current Scryfall printing (so the output stays importable), emitting a Warning instead of dropping the row. A hand-curated `RetiredSetAliases` map (`MB1→PLST`) steers known retirements to the successor set, so both DragonShield and Manabox `MB1` rows land on `plst/AER-13`; unknown codes fall back to any printing of the name.

This is **not** the `all_cards` switch the issue originally proposed. `all_cards` only adds language variants of the same printings, so it would not have resolved these (verified against the live card data — the failing coordinate is dead in every bundle). `all_cards` is the right basis for #103 (foreign-language names), not for reprint resolution.

## Notes / known limits

- `deckbox-real-export.csv` known divergences drop 5→1; the remaining one is the legitimate Alpha `#13`→`LEA #13` wrong-card case, which correctly still errors.
- Round-trip is normalizing: `DragonShield → canonical → DragonShield` rewrites `MB1/62 → plst/AER-13` and can't restore the dead coordinate. Accepted — it is only lossy for an already-obsolete coordinate.
- Whether each target site accepts `plst`-style coordinates on re-import is empirical; a follow-up will verify with real exports/re-imports per site.
- Scryfall-ID resolution (Manabox carries IDs) was scoped but proved redundant here since the `MB1` alias covers Manabox too; easy to add later for non-aliased-but-ID-bearing cases.

258 tests pass.
