### PR TITLE
Add weird-product cards (MB2, Secret Lair, guild kit, playtest) to master.csv reference

### DIFF
--- a/MtgCsvHelper.Tests/Resources/master.csv
+++ b/MtgCsvHelper.Tests/Resources/master.csv
@@ -20,3 +20,7 @@ Folder,Count,TradeQuantity,Name,Set,SetName,CollectorNumber,Condition,Finish,Lan
 ,1,0,Lightning Bolt,M11,Magic 2011,149,NearMint,nonfoil,ru,,
 ,1,0,Lightning Bolt,M11,Magic 2011,149,NearMint,nonfoil,zhs,,
 ,1,0,Lightning Bolt,M11,Magic 2011,149,NearMint,nonfoil,zht,,
+,1,0,Mardu Outrider,MB2,Mystery Booster 2,1,NearMint,nonfoil,en,,
+,1,0,Viscera Seer,SLD,Secret Lair Drop,VS,NearMint,foil,en,,
+,1,0,"Isperia, Supreme Judge",GK2,RNA Guild Kit,1,NearMint,foil,en,,
+,1,0,Ral's Vanguard,CMB1,Mystery Booster Playtest Cards 2019,1,NearMint,nonfoil,en,,

--- a/MtgCsvHelper/Resources/SampleCsvs/Reference/archidekt.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Reference/archidekt.csv
@@ -20,3 +20,7 @@ Quantity,Name,Edition Code,Edition Name,Collector Number,Condition,Finish,Langua
 1,Lightning Bolt,M11,Magic 2011,149,NM,Normal,RU,,
 1,Lightning Bolt,M11,Magic 2011,149,NM,Normal,CS,,
 1,Lightning Bolt,M11,Magic 2011,149,NM,Normal,CT,,
+1,Mardu Outrider,MB2,Mystery Booster 2,1,NM,Normal,EN,,
+1,Viscera Seer,SLD,Secret Lair Drop,VS,NM,Foil,EN,,
+1,"Isperia, Supreme Judge",GK2,RNA Guild Kit,1,NM,Foil,EN,,
+1,Ral's Vanguard,CMB1,Mystery Booster Playtest Cards 2019,1,NM,Normal,EN,,

--- a/MtgCsvHelper/Resources/SampleCsvs/Reference/cardkingdom.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Reference/cardkingdom.csv
@@ -20,3 +20,7 @@ Lightning Bolt,Magic 2011,FALSE,1
 Lightning Bolt,Magic 2011,FALSE,1
 Lightning Bolt,Magic 2011,FALSE,1
 Lightning Bolt,Magic 2011,FALSE,1
+Mardu Outrider,Mystery Booster 2,FALSE,1
+Viscera Seer,Secret Lair Drop,TRUE,1
+"Isperia, Supreme Judge",RNA Guild Kit,TRUE,1
+Ral's Vanguard,Mystery Booster Playtest Cards 2019,FALSE,1

--- a/MtgCsvHelper/Resources/SampleCsvs/Reference/deckbox.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Reference/deckbox.csv
@@ -20,3 +20,7 @@ Count,Name,Card Number,Condition,Edition,Foil,Edition Code,Language,My Price
 1,Lightning Bolt,149,Near Mint,Magic 2011,,M11,Russian,
 1,Lightning Bolt,149,Near Mint,Magic 2011,,M11,Chinese,
 1,Lightning Bolt,149,Near Mint,Magic 2011,,M11,Traditional Chinese,
+1,Mardu Outrider,1,Near Mint,Mystery Booster 2,,MB2,English,
+1,Viscera Seer,VS,Near Mint,Secret Lair Drop Series,foil,SLD,English,
+1,"Isperia, Supreme Judge",1,Near Mint,Ravnica Allegiance Guild Kit,foil,GK2,English,
+1,Ral's Vanguard,1,Near Mint,Mystery Booster Playtest Cards,,CMB1,English,

--- a/MtgCsvHelper/Resources/SampleCsvs/Reference/dragonshield.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Reference/dragonshield.csv
@@ -20,3 +20,7 @@ Imported,1,0,Lightning Bolt,M11,Magic 2011,149,NearMint,Normal,Korean,0,2024-01-
 Imported,1,0,Lightning Bolt,M11,Magic 2011,149,NearMint,Normal,Russian,0,2024-01-01
 Imported,1,0,Lightning Bolt,M11,Magic 2011,149,NearMint,Normal,Chinese,0,2024-01-01
 Imported,1,0,Lightning Bolt,M11,Magic 2011,149,NearMint,Normal,Traditional Chinese,0,2024-01-01
+Imported,1,0,Mardu Outrider,MB2,Mystery Booster 2,1,NearMint,Normal,English,0,2024-01-01
+Imported,1,0,Viscera Seer,SLD,Secret Lair Drop,VS,NearMint,Foil,English,0,2024-01-01
+Imported,1,0,"Isperia, Supreme Judge",GK2,RNA Guild Kit,1,NearMint,Foil,English,0,2024-01-01
+Imported,1,0,Ral's Vanguard,CMB1,Mystery Booster Playtest Cards 2019,1,NearMint,Normal,English,0,2024-01-01

--- a/MtgCsvHelper/Resources/SampleCsvs/Reference/manabox.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Reference/manabox.csv
@@ -20,3 +20,7 @@ Quantity,Name,Set code,Set name,Collector number,Condition,Foil,Language,Purchas
 1,Lightning Bolt,M11,Magic 2011,149,near_mint,normal,ru,
 1,Lightning Bolt,M11,Magic 2011,149,near_mint,normal,zh_CN,
 1,Lightning Bolt,M11,Magic 2011,149,near_mint,normal,zh_TW,
+1,Mardu Outrider,MB2,Mystery Booster 2,1,near_mint,normal,en,
+1,Viscera Seer,SLD,Secret Lair Drop,VS,near_mint,foil,en,
+1,"Isperia, Supreme Judge",GK2,RNA Guild Kit,1,near_mint,foil,en,
+1,Ral's Vanguard,CMB1,Mystery Booster Playtest Cards 2019,1,near_mint,normal,en,

--- a/MtgCsvHelper/Resources/SampleCsvs/Reference/moxfield.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Reference/moxfield.csv
@@ -20,3 +20,7 @@ Count,Name,Edition,Collector Number,Condition,Foil,Language,Purchase Price
 1,Lightning Bolt,M11,149,Near Mint,,Russian,
 1,Lightning Bolt,M11,149,Near Mint,,Chinese,
 1,Lightning Bolt,M11,149,Near Mint,,Traditional Chinese,
+1,Mardu Outrider,MB2,1,Near Mint,,English,
+1,Viscera Seer,SLD,VS,Near Mint,foil,English,
+1,"Isperia, Supreme Judge",GK2,1,Near Mint,foil,English,
+1,Ral's Vanguard,CMB1,1,Near Mint,,English,

--- a/MtgCsvHelper/Resources/SampleCsvs/Reference/mtggoldfish.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Reference/mtggoldfish.csv
@@ -20,3 +20,7 @@ Quantity,Card,Set ID,Set Name,Collector Number,Foil
 1,Lightning Bolt,M11,Magic 2011,149,regular
 1,Lightning Bolt,M11,Magic 2011,149,regular
 1,Lightning Bolt,M11,Magic 2011,149,regular
+1,Mardu Outrider,MB2,Mystery Booster 2,1,regular
+1,Viscera Seer,SLD,Secret Lair Drop,VS,foil
+1,"Isperia, Supreme Judge",GK2,RNA Guild Kit,1,foil
+1,Ral's Vanguard,CMB1,Mystery Booster Playtest Cards 2019,1,regular

--- a/MtgCsvHelper/Resources/SampleCsvs/Reference/mtgo.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Reference/mtgo.csv
@@ -20,3 +20,7 @@ Quantity,Card Name,Set,Collector #,Premium
 1,Lightning Bolt,M11,149,No
 1,Lightning Bolt,M11,149,No
 1,Lightning Bolt,M11,149,No
+1,Mardu Outrider,MB2,1,No
+1,Viscera Seer,SLD,VS,Yes
+1,"Isperia, Supreme Judge",GK2,1,Yes
+1,Ral's Vanguard,CMB1,1,No

--- a/MtgCsvHelper/Resources/SampleCsvs/Reference/tcgplayer.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Reference/tcgplayer.csv
@@ -20,3 +20,7 @@ Quantity,Simple Name,Set Code,Set,Card Number,Condition,Name,Printing,Language
 1,Lightning Bolt,M11,Magic 2011,149,Near Mint,Lightning Bolt,Normal,Russian
 1,Lightning Bolt,M11,Magic 2011,149,Near Mint,Lightning Bolt,Normal,Chinese
 1,Lightning Bolt,M11,Magic 2011,149,Near Mint,Lightning Bolt,Normal,Traditional Chinese
+1,Mardu Outrider,MB2,Mystery Booster 2,1,Near Mint,Mardu Outrider,Normal,English
+1,Viscera Seer,SLD,Secret Lair Drop,VS,Near Mint,Viscera Seer,Foil,English
+1,"Isperia, Supreme Judge",GK2,RNA Guild Kit,1,Near Mint,"Isperia, Supreme Judge",Foil,English
+1,Ral's Vanguard,CMB1,Mystery Booster Playtest Cards 2019,1,Near Mint,Ral's Vanguard,Normal,English

--- a/MtgCsvHelper/Resources/SampleCsvs/Reference/topdecked.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Reference/topdecked.csv
@@ -20,3 +20,7 @@ QUANTITY,NAME,SETCODE,SETNAME,COLLECTOR NUMBER,CONDITION,FINISH,LANG,ACQUIRED PR
 1,Lightning Bolt,M11,Magic 2011,149,near mint,nonfoil,ru,
 1,Lightning Bolt,M11,Magic 2011,149,near mint,nonfoil,zhs,
 1,Lightning Bolt,M11,Magic 2011,149,near mint,nonfoil,zht,
+1,Mardu Outrider,MB2,Mystery Booster 2,1,near mint,nonfoil,en,
+1,Viscera Seer,SLD,Secret Lair Drop,VS,near mint,foil,en,
+1,"Isperia, Supreme Judge",GK2,RNA Guild Kit,1,near mint,foil,en,
+1,Ral's Vanguard,CMB1,Mystery Booster Playtest Cards 2019,1,near mint,nonfoil,en,


### PR DESCRIPTION
Extends the `master.csv` canonical reference collection with non-standard products so the round-trip and reference-sync tests exercise them:

- **Mystery Booster 2** (`MB2/1`, Mardu Outrider)
- **Secret Lair** (`SLD/VS`, Viscera Seer — foil-only, alphanumeric collector number)
- **RNA Guild Kit** (`GK2/1`, Isperia, Supreme Judge — foil-only, comma in name)
- **Mystery Booster playtest** (`CMB1/1`, Ral's Vanguard — `vanguard` layout)

All four parse cleanly and round-trip through every writable format. Regenerated the per-format reference CSVs under `MtgCsvHelper/Resources/SampleCsvs/Reference/`.

Follow-on to the reprint-resolution work in #120 (the resolver fix); independent of it (these use valid current coordinates). 256 tests pass.
