### PR TITLE
Extract ConfigureSetName/SetCode hooks in PhysicalCardMap (#88)

### DIFF
--- a/MtgCsvHelper/GlobalSuppressions.cs
+++ b/MtgCsvHelper/GlobalSuppressions.cs
@@ -1,0 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Usage", "CA2214:Do not call overridable methods in constructors",
+	Scope = "type", Target = "~T:MtgCsvHelper.Maps.PhysicalCardMap",
+	Justification = "ConfigureSetCode/ConfigureSetName are configuration extension points invoked during ClassMap setup, which by design happens in the constructor. The overrides use only static lookup tables and the MemberMap passed to them — never derived instance state — so the partially-constructed-object hazard CA2214 guards against does not apply.")]

--- a/MtgCsvHelper/Maps/DeckboxMap.cs
+++ b/MtgCsvHelper/Maps/DeckboxMap.cs
@@ -1,74 +1,40 @@
+using CsvHelper.Configuration;
 using MtgCsvHelper.Converters;
 using ScryfallApi.Client.Models;
 
 namespace MtgCsvHelper.Maps;
 
-// Bidirectional map for the DECKBOX format. Inherits the standard PhysicalCardMap shape, then
-// patches the two columns where Deckbox diverges from Scryfall:
-//
-//   - WRITE: Edition (SetName) — Deckbox curates its own edition names ("Magic 2014 Core Set"
-//     vs Scryfall's "Magic 2014", "Promo Pack: Kamigawa: Neon Dynasty" vs "Kamigawa: Neon
-//     Dynasty Promos", etc.). The mismatches live in `deckbox-set-aliases.json`; sets without
-//     an entry fall back to Scryfall canonical (the ~95% of editions where they agree).
-//
-//   - READ:  Edition Code (Set)  — Deckbox uses internal codes like `ex_127` or `pp_neo` that
-//     don't resolve in the Scryfall catalog. `deckbox-code-aliases.json` translates them back
-//     to Scryfall codes (TMH2, PNEO, …) before CatalogValidator runs.
-//
-// Both resource files are emitted by `tools/MtgCsvHelper.RefreshReferenceData -- deckbox-aliases`.
+/// <summary>
+/// Bidirectional map for the DECKBOX format. Inherits the standard <see cref="PhysicalCardMap"/> shape
+/// and customizes the two columns where Deckbox diverges from Scryfall, via the Configure* hooks:
+/// <list type="bullet">
+///   <item><b>Write</b> (Edition / SetName): Deckbox curates its own edition names ("Magic 2014 Core
+///   Set" vs Scryfall's "Magic 2014", etc.) from <c>deckbox-set-aliases.json</c>; sets without an entry
+///   fall back to the Scryfall canonical name.</item>
+///   <item><b>Read</b> (Edition Code / Set): Deckbox-internal codes like <c>ex_127</c> / <c>pp_neo</c> are
+///   translated back to Scryfall codes (<c>deckbox-code-aliases.json</c>) before CatalogValidator runs.</item>
+/// </list>
+/// Both resource files are emitted by <c>tools/MtgCsvHelper.RefreshReferenceData -- deckbox-aliases</c>.
+/// </summary>
 public class DeckboxMap : PhysicalCardMap
 {
 	internal static readonly IReadOnlyDictionary<string, string> SetCodeToDeckboxName = EmbeddedResources.LoadStringMap("deckbox-set-aliases.json");
 	internal static readonly IReadOnlyDictionary<string, string> DeckboxCodeToScryfallCode = EmbeddedResources.LoadStringMap("deckbox-code-aliases.json");
 
-	public DeckboxMap(FormatConfig cfg, IReferenceCardCatalog catalog) : base(cfg, catalog)
-	{
-		// We reach into CsvHelper's `ReferenceMaps.Data.Mapping.MemberMaps` to swap two member
-		// mappings after the base ctor has registered the defaults. This relies on those
-		// collections being publicly mutable — they are in CsvHelper 33, but a major upgrade
-		// could change the API. The alternative — duplicating all PhysicalCardMap mappings
-		// here (like CardKingdomWriteMap does) — drifts on every change to the base map.
-		// Tracked in #88: extract `protected virtual ConfigureSetName/SetCode` hooks in
-		// PhysicalCardMap to lift this out of CsvHelper internals.
-		var printingRef = ReferenceMaps.FirstOrDefault(r => r.Data.Member?.Name == nameof(PhysicalMtgCard.Printing))
-			?? throw new InvalidOperationException($"Expected `Printing` ReferenceMap from base PhysicalCardMap for '{cfg.Name}'.");
+	public DeckboxMap(FormatConfig cfg, IReferenceCardCatalog catalog) : base(cfg, catalog) { }
 
-		// SetName (Edition column) — replace the default member access with a write-side Convert
-		// that gets the whole PhysicalMtgCard, because the alias lookup is keyed by Set *code*.
-		// Drops in via Optional() so reads of a missing column don't throw.
-		if (cfg.SetName is not null)
+	/// <summary>Read side: translate Deckbox-internal codes (ex_127, pp_neo) to Scryfall codes before validation.</summary>
+	protected override void ConfigureSetCode(MemberMap<PhysicalMtgCard, string> map) =>
+		map.TypeConverter(new DeckboxCodeReadConverter(DeckboxCodeToScryfallCode));
+
+	/// <summary>Write side: emit Deckbox's curated edition name (keyed by Set code), else the canonical SetName.</summary>
+	protected override void ConfigureSetName(MemberMap<PhysicalMtgCard, string> map) =>
+		map.Convert(args =>
 		{
-			var existing = printingRef.Data.Mapping.MemberMaps.FirstOrDefault(m => m.Data.Names.Contains(cfg.SetName))
-				?? throw new InvalidOperationException($"Expected SetName MemberMap in Printing reference for '{cfg.Name}' (header '{cfg.SetName}').");
-			printingRef.Data.Mapping.MemberMaps.Remove(existing);
-
-			Map(c => c.Printing.SetName).Name(cfg.SetName).Index(5).Optional()
-				.Convert(args =>
-				{
-					var card = args.Value;
-					// Set can be null on rows that escaped SetInfoEnricher without a catalog hit
-					// (no Edition + no recognizable Edition Code). Dictionary<string,string> with
-					// OrdinalIgnoreCase throws ArgumentNullException on a null key, so guard before
-					// the lookup and fall straight to SetName for those rows.
-					return card.Printing.Set is not null
-						&& SetCodeToDeckboxName.TryGetValue(card.Printing.Set, out var alias)
-						? alias
-						: card.Printing.SetName;
-				});
-		}
-
-		// SetCode (Edition Code column) — wrap the read side so Deckbox-internal codes like
-		// `ex_127` get translated to Scryfall codes (TMH2) before CatalogValidator looks them up.
-		// Write side is identity: we already store Scryfall codes in card.Printing.Set, and
-		// Scryfall codes resolve fine on Deckbox import.
-		if (cfg.SetCode is not null)
-		{
-			var existing = printingRef.Data.Mapping.MemberMaps.FirstOrDefault(m => m.Data.Names.Contains(cfg.SetCode))
-				?? throw new InvalidOperationException($"Expected SetCode MemberMap in Printing reference for '{cfg.Name}' (header '{cfg.SetCode}').");
-			printingRef.Data.Mapping.MemberMaps.Remove(existing);
-
-			Map(c => c.Printing.Set).Name(cfg.SetCode).Index(4).Optional()
-				.TypeConverter(new DeckboxCodeReadConverter(DeckboxCodeToScryfallCode));
-		}
-	}
+			var card = args.Value;
+			// Guard the OrdinalIgnoreCase lookup: Set is null on rows SetInfoEnricher couldn't resolve.
+			return card.Printing.Set is not null && SetCodeToDeckboxName.TryGetValue(card.Printing.Set, out var alias)
+				? alias
+				: card.Printing.SetName;
+		});
 }

--- a/MtgCsvHelper/Maps/DragonShieldMap.cs
+++ b/MtgCsvHelper/Maps/DragonShieldMap.cs
@@ -1,3 +1,4 @@
+using CsvHelper.Configuration;
 using MtgCsvHelper.Converters;
 using MtgCsvHelper.Models;
 
@@ -5,7 +6,8 @@ namespace MtgCsvHelper.Maps;
 
 /// <summary>
 /// Bidirectional map for the DRAGONSHIELD format. Inherits the standard <see cref="PhysicalCardMap"/>
-/// shape, then handles Ravnica Guild Kits, which DragonShield splits into per-guild editions:
+/// shape and customizes two columns via the Configure* hooks, for Ravnica Guild Kits (which DragonShield
+/// splits into per-guild editions):
 /// <list type="bullet">
 ///   <item><b>Read</b>: the <c>GK1_*/GK2_*</c> set codes DragonShield exports collapse to canonical gk1/gk2 via <see cref="DragonShieldCodeReadConverter"/>.</item>
 ///   <item><b>Write</b>: DragonShield resolves imports by Set <em>Name</em>, not Set Code, so guild-kit cards
@@ -19,21 +21,15 @@ public sealed class DragonShieldMap : PhysicalCardMap
 {
 	internal static readonly IReadOnlyDictionary<string, string> GuildKitEditions = EmbeddedResources.LoadStringMap("dragonshield-guildkit-editions.json");
 
-	public DragonShieldMap(FormatConfig cfg, IReferenceCardCatalog catalog)
-		: base(cfg, catalog, new DragonShieldCodeReadConverter())
-	{
-		// Patch Set Name with a whole-card write Convert — a per-cell converter can't see the collector number the guild lookup needs (same surgery as DeckboxMap).
-		if (cfg.SetName is null) { return; }
+	public DragonShieldMap(FormatConfig cfg, IReferenceCardCatalog catalog) : base(cfg, catalog) { }
 
-		var printingRef = ReferenceMaps.FirstOrDefault(r => r.Data.Member?.Name == nameof(PhysicalMtgCard.Printing))
-			?? throw new InvalidOperationException($"Expected `Printing` ReferenceMap from base PhysicalCardMap for '{cfg.Name}'.");
-		var existing = printingRef.Data.Mapping.MemberMaps.FirstOrDefault(m => m.Data.Names.Contains(cfg.SetName))
-			?? throw new InvalidOperationException($"Expected Set Name MemberMap in Printing reference for '{cfg.Name}' (header '{cfg.SetName}').");
-		printingRef.Data.Mapping.MemberMaps.Remove(existing);
+	/// <summary>Read side: collapse the proprietary <c>GK1_*/GK2_*</c> set codes to canonical gk1/gk2.</summary>
+	protected override void ConfigureSetCode(MemberMap<PhysicalMtgCard, string> map) =>
+		map.TypeConverter(new DragonShieldCodeReadConverter());
 
-		Map(c => c.Printing.SetName).Name(cfg.SetName).Index(5).Optional()
-			.Convert(args => ToGuildKitEdition(args.Value));
-	}
+	/// <summary>Write side: emit the native per-guild <c>Guild Kit: &lt;Guild&gt;</c> edition for gk1/gk2 cards; else the canonical set name.</summary>
+	protected override void ConfigureSetName(MemberMap<PhysicalMtgCard, string> map) =>
+		map.Convert(args => ToGuildKitEdition(args.Value));
 
 	/// <summary>gk1/gk2 cards get DragonShield's per-guild <c>Guild Kit: &lt;Guild&gt;</c> edition; everything else keeps its set name.</summary>
 	static string ToGuildKitEdition(PhysicalMtgCard card)

--- a/MtgCsvHelper/Maps/PhysicalCardMap.cs
+++ b/MtgCsvHelper/Maps/PhysicalCardMap.cs
@@ -10,7 +10,7 @@ namespace MtgCsvHelper.Maps;
 // so the body reads as a flat list of mappings rather than a forest of null checks.
 public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 {
-	public PhysicalCardMap(FormatConfig cfg, IReferenceCardCatalog catalog, ITypeConverter? setCodeConverter = null)
+	public PhysicalCardMap(FormatConfig cfg, IReferenceCardCatalog catalog)
 	{
 		// Explicit indices override CsvHelper's clustering of nested-member maps
 		// (Printing.Name, Printing.Set, …) — registration order alone interleaves
@@ -39,8 +39,10 @@ public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 		// At least one of SetCode / SetName is expected per format (sites differ on which they include).
 		// CollectorNumberConverter is applied universally (not MTGO-specific) — it's a no-op for any
 		// collector number without a "/", and "/" doesn't appear in Scryfall data.
-		MapOptional(c => c.Printing.Set, cfg.SetCode)?.TypeConverter(setCodeConverter ?? new UpperCaseConverter()).Index(4);
-		MapOptional(c => c.Printing.SetName, cfg.SetName)?.Index(5);
+		var setCodeMap = MapOptional(c => c.Printing.Set, cfg.SetCode);
+		if (setCodeMap is not null) { ConfigureSetCode(setCodeMap.Index(4)); }
+		var setNameMap = MapOptional(c => c.Printing.SetName, cfg.SetName);
+		if (setNameMap is not null) { ConfigureSetName(setNameMap.Index(5)); }
 		MapOptional(c => c.Printing.CollectorNumber, cfg.SetNumber)?.TypeConverter<CollectorNumberConverter>().Index(6);
 
 		// Printing.Id is a non-nullable Guid, so it can't go through MapOptional (which expects a nullable member).
@@ -57,6 +59,12 @@ public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 				.TypeConverterOption.Format(cfg.DateBought.FormatsOrDefault);
 		}
 	}
+
+	/// <summary>Configures the Set Code column; default uppercases the canonical Scryfall code. Override to swap the read converter for formats with proprietary codes (Deckbox, Dragon Shield).</summary>
+	protected virtual void ConfigureSetCode(MemberMap<PhysicalMtgCard, string> map) => map.TypeConverter<UpperCaseConverter>();
+
+	/// <summary>Configures the Set Name column; default is pass-through. Override to emit a format's curated edition names (Deckbox aliases, Dragon Shield guild kits).</summary>
+	protected virtual void ConfigureSetName(MemberMap<PhysicalMtgCard, string> map) { }
 
 	MemberMap<PhysicalMtgCard, TMember>? MapOptional<TMember>(
 		Expression<Func<PhysicalMtgCard, TMember?>> property,


### PR DESCRIPTION
DeckboxMap and DragonShieldMap reached into CsvHelper's `ReferenceMaps[…].Data.Mapping.MemberMaps` to remove + re-add the Set / Set Name maps after the base ctor — a public-but-undocumented CsvHelper-33 contract that a major upgrade could break silently.

Replaces that with two `protected virtual` hooks on `PhysicalCardMap`:

```csharp
protected virtual void ConfigureSetCode(MemberMap<PhysicalMtgCard, string> map) => map.TypeConverter<UpperCaseConverter>();
protected virtual void ConfigureSetName(MemberMap<PhysicalMtgCard, string> map) { }
```

The base ctor maps the Set / Set Name columns (with their indices) and calls the hooks on the freshly-created `MemberMap`s. Subclasses override to:
- **Deckbox** — `ConfigureSetCode` swaps in `DeckboxCodeReadConverter`; `ConfigureSetName` adds the curated-edition write Convert.
- **Dragon Shield** — `ConfigureSetCode` swaps in `DragonShieldCodeReadConverter`; `ConfigureSetName` adds the guild-kit edition write Convert.

No format touches `ReferenceMaps` anymore (DeckboxMap 75→40 lines). The hook signature is `(MemberMap)` only — neither override needs `cfg`/`catalog`, so they're left out (YAGNI).

## Notes
- **Behavior-preserving**: the generated reference CSVs are byte-identical (same converters/Convert at the same indices). 273 tests pass, none changed.
- Drops the now-unused `setCodeConverter` base-ctor parameter (only Dragon Shield used it).
- **CA2214** (virtual call in ctor) is suppressed for `PhysicalCardMap` in a new `GlobalSuppressions.cs`, with justification: the hooks are stateless config extension points invoked during `ClassMap` setup (which happens in the ctor), and the overrides use only static lookup tables + the passed map — never derived instance state.

Closes #88.