### PR TITLE
Resolve rows by Scryfall id before (set, #) (#130)

### DIFF
--- a/MtgCsvHelper.Tests/ScryfallIdTests.cs
+++ b/MtgCsvHelper.Tests/ScryfallIdTests.cs
@@ -2,7 +2,8 @@ using System.Text;
 
 namespace MtgCsvHelper.Tests;
 
-/// <summary>CatalogValidator backfills the resolved Scryfall id onto Printing.Id; writers emit it where the format declares a Scryfall ID column.</summary>
+/// <summary>CatalogValidator resolves a row by its Scryfall id when present (correcting a reshaped (set, #)),
+/// backfills the resolved id onto Printing.Id, and writers emit it where the format declares a Scryfall ID column.</summary>
 [Collection(CatalogCollection.Name)]
 public class ScryfallIdTests(CatalogFixture fixture, ITestOutputHelper output) : ApiBaseTest(fixture, output)
 {
@@ -48,5 +49,25 @@ public class ScryfallIdTests(CatalogFixture fixture, ITestOutputHelper output) :
 		var id = Isperia(cards).Printing.Id.ToString("D");
 
 		Write("MOXFIELD", cards).Should().NotContain(id, because: "Moxfield has no Scryfall ID column to emit it into");
+	}
+
+	[Fact]
+	public void ScryfallId_OverridesReshapedCoordinate_OnRead()
+	{
+		// (set, #) lea #13 is Circle of Protection: White, not Demonic Tutor; the id pins the real lea #104.
+		const string csv = """
+			QUANTITY,"NAME",SETCODE,"SETNAME","COLLECTOR NUMBER",FINISH,PRICE,RARITY,ID,ACQUIRED DATE,ACQUIRED PRICE,LANG,PRICE SALE,SIGNING,ALTERATION,CONDITION,NOTES,TAGS
+			1,"Demonic Tutor",lea,"Limited Edition Alpha",13,nonfoil,,uncommon,711d4d54-5520-4de8-9b93-79902ed8e562,2023-01-01T00:00:00.000Z,,en,,,false,near mint
+			""";
+		var handler = new MtgCardCsvHandler(_catalog, _resolver, _config, "TOPDECKED");
+		using var stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
+
+		var result = handler.ParseCollectionCsv(stream);
+
+		result.ErrorCount.Should().Be(0, because: "the Scryfall id resolves even though (set, #) names a different card");
+		var card = result.Collection.Cards.Should().ContainSingle().Subject;
+		card.Printing.Name.Should().Be("Demonic Tutor");
+		card.Printing.Set.Should().Be("LEA", because: "the id rewrites the full coordinate from the catalog");
+		card.Printing.CollectorNumber.Should().Be("104", because: "the id pins lea #104, correcting the reshaped #13 coordinate");
 	}
 }

--- a/MtgCsvHelper.Tests/TestCollectionFixtureTests.cs
+++ b/MtgCsvHelper.Tests/TestCollectionFixtureTests.cs
@@ -56,14 +56,12 @@ public class TestCollectionFixtureTests(CatalogFixture fixture, ITestOutputHelpe
 	/// <summary>
 	/// Fixtures with documented site-specific divergence from Scryfall. The listed error count is
 	/// expected; the mixed-assertion still forbids silent drops (cards + errors == data rows).
-	/// Most of Deckbox's legacy-set reprints (The List, Alliances, Box Toppers) now recover via the
-	/// stale-coordinate name rewrite. The one remaining error is an Alpha collector-number divergence:
-	/// Deckbox's Alpha #13 aliases to LEA #13, which is a different card, so the name can't match the coordinate.
+	/// Currently empty: every real export round-trips cleanly. The last holdout was Deckbox's Alpha #13
+	/// (Demonic Tutor) — Deckbox numbers Alpha by its own scheme, so the coordinate aliases to lea #13
+	/// (Circle of Protection: White), a different card. Scryfall-ID resolution now pins it to lea #104.
+	/// The map stays as the place to document any future divergence a site exports without a usable id.
 	/// </summary>
-	static readonly IReadOnlyDictionary<string, (int ExpectedErrors, string Divergence)> KnownDivergence = new Dictionary<string, (int, string)>
-	{
-		["deckbox-real-export.csv"] = (ExpectedErrors: 1, Divergence: "legacy-set collector-number divergences"),
-	};
+	static readonly IReadOnlyDictionary<string, (int ExpectedErrors, string Divergence)> KnownDivergence = new Dictionary<string, (int, string)>();
 
 	[Theory]
 	[MemberData(nameof(CorrectFixtures))]

--- a/MtgCsvHelper/Enrichment/CatalogValidator.cs
+++ b/MtgCsvHelper/Enrichment/CatalogValidator.cs
@@ -4,9 +4,11 @@ using System.Text;
 namespace MtgCsvHelper.Enrichment;
 
 /// <summary>
-/// The one validator in the post-parse pipeline. Drops rows whose (Set, CollectorNumber)
-/// doesn't resolve, whose Name doesn't match the resolved printing, or whose Finish
-/// claims an unsupported finish. Named "Validator" rather than "Enricher" because it mainly
+/// The one validator in the post-parse pipeline. Resolves each row to a catalog printing — by the
+/// Scryfall id when the row carries one (authoritative; survives sites that reshape collector
+/// numbers), else by (Set, CollectorNumber). Drops rows that don't resolve, whose Name doesn't match
+/// the resolved printing, or whose Finish claims an unsupported finish.
+/// Named "Validator" rather than "Enricher" because it mainly
 /// checks-and-drops; its only mutations are the issues collection, canonicalizing the
 /// name of a short-named or front-face-ambiguous double-faced card to the resolved printing,
 /// and backfilling Rarity and the Scryfall Id from the resolved printing.
@@ -21,6 +23,22 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 		// stubs that a later enricher will fill in (Cardmarket); validating now would error
 		// on data that isn't actually broken.
 		if (string.IsNullOrEmpty(p.Name)) { return true; }
+
+		// A populated Scryfall id pins the exact printing — trust it over (Set, #), which some sites reshape on export.
+		if (p.Id != Guid.Empty && catalog.FindById(p.Id) is { } byId)
+		{
+			if (FinishUnavailable(row, byId, issues)) { return false; }
+
+			// The id is the identity; adopt its name outright — no mismatch guard like the (set, #) path runs.
+			p.Name = byId.Name;
+			p.Set = byId.Set;
+			p.SetName = byId.SetName;
+			p.CollectorNumber = byId.CollectorNumber;
+			row = row with { Card = row.Card with { Rarity = byId.Rarity } };
+
+			return true;
+		}
+
 		if (string.IsNullOrEmpty(p.Set) || string.IsNullOrEmpty(p.CollectorNumber)) { return true; }
 
 		var match = catalog.FindBySetAndCollectorNumber(p.Set, p.CollectorNumber);
@@ -63,13 +81,7 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 			p.Name = match.Name;
 		}
 
-		if ((row.Card.Finish is CardFinish.Foil or CardFinish.Etched) && !HasFoilFinish(match.Finishes))
-		{
-			issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
-				$"Printing {p.Set} #{p.CollectorNumber} was not released in foil",
-				CardName: p.Name, RawContent: row.RawContent));
-			return false;
-		}
+		if (FinishUnavailable(row, match, issues)) { return false; }
 
 		p.Id = match.Id;
 		row = row with { Card = row.Card with { Rarity = match.Rarity } };
@@ -99,6 +111,18 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 			if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark) { sb.Append(c); }
 		}
 		return sb.ToString();
+	}
+
+	/// <summary>A foil/etched mark on a printing never released in that finish is a site data conflict; records an error and signals the row should drop.</summary>
+	static bool FinishUnavailable(ParsedRow row, ReferenceCard printing, ICollection<ImportIssue> issues)
+	{
+		if (row.Card.Finish is not (CardFinish.Foil or CardFinish.Etched) || HasFoilFinish(printing.Finishes)) { return false; }
+
+		issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
+			$"Printing {printing.Set} #{printing.CollectorNumber} was not released in foil",
+			CardName: printing.Name, RawContent: row.RawContent));
+
+		return true;
 	}
 
 	static bool HasFoilFinish(IReadOnlyList<string> finishes) =>

--- a/MtgCsvHelper/Resources/SampleCsvs/Tests/topdecked-field-fidelity.csv
+++ b/MtgCsvHelper/Resources/SampleCsvs/Tests/topdecked-field-fidelity.csv
@@ -6,5 +6,5 @@ QUANTITY,"NAME",SETCODE,"SETNAME","COLLECTOR NUMBER",FINISH,PRICE,RARITY,ID,ACQU
 1,"Ambitious Farmhand // Seasoned Cathar",mid,"Innistrad: Midnight Hunt",2,nonfoil,,uncommon,54d4e7c3-294d-4900-8b70-faafda17cc33,2023-12-20T09:03:42.147Z,,en,,,false,moderately played
 1,"Ambitious Farmhand // Seasoned Cathar",mid,"Innistrad: Midnight Hunt",2,nonfoil,,uncommon,54d4e7c3-294d-4900-8b70-faafda17cc33,2023-12-20T09:03:42.147Z,,en,,,false,heavily played
 1,"Ambitious Farmhand // Seasoned Cathar",mid,"Innistrad: Midnight Hunt",2,nonfoil,,uncommon,54d4e7c3-294d-4900-8b70-faafda17cc33,2023-12-20T09:03:42.147Z,,en,,,false,damaged
-1,"Clue",tmh2,"Modern Horizons 2 Tokens",14,nonfoil,,common,eb129b0d-1349-4e88-a6a7-b7968b26ee7e,2022-09-15T09:58:08.858Z,0.15,en,,,false,near mint
+1,"Clue",tmh2,"Modern Horizons 2 Tokens",14,nonfoil,,common,cfcf6efe-9f94-4a55-9994-701e596691ad,2022-09-15T09:58:08.858Z,0.15,en,,,false,near mint
 1,"Food",tltr,"Tales of Middle-earth Tokens",10,nonfoil,,common,bfcff41e-b6ff-4ddd-bcb6-8943f7d88aef,2023-12-22T17:02:09.849Z,0.11,en,,,false,near mint


### PR DESCRIPTION
Closes #130.

## What

`CatalogValidator` now resolves a row by its **Scryfall id** when one is present, trusting it over `(Set, CollectorNumber)`. Several sites reshape the coordinate on export (Deckbox numbers Alpha by its own scheme; The List / Mystery Booster reshape collector numbers), so the stable id is the more reliable identity. This is the read-side payoff of carrying the id through (#127): a row with an id resolves to the exact printing and the coordinate is corrected from it; the `(Set, #)` lookup is the fallback when no usable id is present.

The new id path was initially bypassing the foil-finish validity check the coordinate path enforces, so I factored that into a shared `FinishUnavailable` helper — both paths now reject an impossible card (e.g. a "foil" Alpha printing) identically.

## Fixture ripple (both genuine improvements)

- **deckbox-real-export**: Deckbox exports Demonic Tutor as Alpha #13, but Scryfall's `lea/13` is *Circle of Protection: White* — a different card. Previously this errored; the row's id now pins `lea #104`. `KnownDivergence` is empty for the first time (kept as a documented extension point for any future divergence a site exports without a usable id).
- **topdecked-field-fidelity**: the Clue row carried an inconsistent id — `eb129b0d` (= `tmh2 #15`) against its own `tmh2/14` coordinate and the canonical collection. resolve-by-id correctly surfaced the conflict; the id is now aligned to `cfcf6efe` (`tmh2 #14`) to match its other three columns and master.csv.

## Test

New `ScryfallId_OverridesReshapedCoordinate_OnRead` proves the mechanism end-to-end (a `lea/13`→`lea/104` correction driven by the id).

Full suite: **274 pass** (`MtgCsvHelper.Tests`).