### PR TITLE
Assert per-fixture bijection in field-fidelity parse test (#119)

### DIFF
--- a/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
+++ b/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
@@ -50,6 +50,21 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 			["DECKBOX"] = new Dictionary<CardFinish, CardFinish> { [CardFinish.Etched] = CardFinish.Foil },
 		};
 
+	/// <summary>
+	/// The canonical printings the field-fidelity fixtures are built from — the Ambitious Farmhand
+	/// language/condition block plus the two tokens. <see cref="ParseSampleCsv_WithValidInput_ParsesCards"/>
+	/// asserts a true bijection against exactly the master rows for these (Name, Set, CollectorNumber)
+	/// printings, so a language- or condition-twin mis-parse fails instead of silently matching a
+	/// different row that shares every other field. All five fixtures share this coverage today; split
+	/// this per-fixture if one ever diverges.
+	/// </summary>
+	static readonly HashSet<(string? Name, string? Set, string? CollectorNumber)> FieldFidelityPrintings =
+	[
+		("Ambitious Farmhand // Seasoned Cathar", "MID", "2"),
+		("Clue", "TMH2", "14"),
+		("Food", "TLTR", "10"),
+	];
+
 	[Theory]
 	[MemberData(nameof(RoundTrippableFormats))]
 	public void ReferenceCollection_RoundTripsThroughFormat(string format)
@@ -137,15 +152,18 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 		// Arrange
 		MtgCardCsvHandler handler = CreateHandler(deckFormatName);
 		IList<PhysicalMtgCard> expectedCards = CanonicalReference.LoadCards(_config, _catalog, _resolver, Currency.FromString(currency));
+		var expectedSubset = expectedCards
+			.Where(c => FieldFidelityPrintings.Contains((c.Printing.Name, c.Printing.Set, c.Printing.CollectorNumber)))
+			.ToList();
 
 		// Act
 		var result = handler.ParseCollectionCsv(csvFilePath);
 		IList<PhysicalMtgCard> cards = result.Collection.Cards;
 
-		// Assert — every data row parses into a canonical card: no errors, no silent drops
+		// Assert — every data row parses into its exact canonical twin: no errors, no silent drops
 		result.ErrorCount.Should().Be(0, $"every field-fidelity row must parse. Issues: {string.Join("; ", result.Issues.Select(i => i.Reason))}");
 		cards.Should().HaveCount(CsvFixture.CountDataRows(csvFilePath), "no data row may be silently dropped");
-		cards.Should().AllSatisfy(c => expectedCards.Should().ContainEquivalentOf(c));
+		cards.Should().BeEquivalentTo(expectedSubset, "each row must parse to its exact canonical twin — matching Language and Condition — not merely some card sharing the other fields");
 	}
 
 	[Theory]


### PR DESCRIPTION
Closes #119.

## Problem

`ParseSampleCsv_WithValidInput_ParsesCards` asserted each parsed card was `ContainEquivalentOf` the **full** canonical set — a non-injective membership check. A language- or condition-twin mis-parse (e.g. `zht` read as `en`) still matched the *wrong* canonical twin, so the test passed silently; the `ErrorCount == 0` and exact-row-count guards are unchanged by a mis-identity.

## Findings while scoping

- All five field-fidelity fixtures resolve to **exactly the same 9 master rows**: Ambitious Farmhand's 7 language/condition variants (`MID` #2) + Clue (`TMH2` #14) + Food (`TLTR` #10).
- The per-format condition vocabularies (`Good (Lightly Played)`, `Heavily Played`, `Damaged`, `slightly/moderately played`, …) are **bijective** mappings, so a clean 1:1 against the master rows *does* exist — the original worry about non-1:1 condition vocab doesn't actually bite.
- The old `ContainEquivalentOf` already used **full** equivalence (no exclusions) and passed, so each parsed card fully equals its master twin. Only the injectivity was missing — so the fix needs no field exclusions.

## Fix

Declare the printings each fixture is built from (`FieldFidelityPrintings`), filter the canonical to exactly those rows, and assert a true `BeEquivalentTo` bijection (order-independent; requires each expected row to be matched by exactly one parsed card). A twin swap now leaves an expected row unmatched and a duplicate produced, failing on the `Language` / `Condition` field.

## Proof it catches the bug

Temporarily flipped the Moxfield `zht` twin to `en` (the exact zht→en mis-parse the issue describes). The tightened test **failed** with `Expected property cards[1].Language … "zht"`, where the old membership check passed (both en rows match the en twin; count/errors unchanged). Reverted after.

Full suite: **274 pass**.

Note: the 11-language Lightning Bolt sweep the issue mentions isn't in any field-fidelity fixture — it lives in `master.csv`, and `ReferenceCollection_RoundTripsThroughFormat` already does a full-canonical `BeEquivalentTo` over all 29 rows, so that surface was already covered. This PR closes the remaining real-fixture **read**-path gap.