### PR TITLE
Simplicity pass: defect fixes, dead code, comment sweep

### DIFF
--- a/MtgCsvHelper.BlazorWebAssembly/CatalogLoader.cs
+++ b/MtgCsvHelper.BlazorWebAssembly/CatalogLoader.cs
@@ -35,8 +35,7 @@ public sealed class CatalogLoader(HttpClient http) : ICatalogLoader
 	const long EstimatedBundleBytes = 12_000_000;  // dev server omits Content-Length; production has it
 
 	readonly HttpClient _http = http;
-	// 0 = idle or failed (retryable); 1 = in-flight or succeeded. Reset to 0 in the catch
-	// so RetryCatalogLoad can call LoadAsync again after a failure.
+	// 0 = idle or failed (retryable), 1 = in-flight or succeeded; the catches reset to 0 so a retry can run.
 	int _started;
 
 	public IReferenceCardCatalog? Catalog { get; private set; }
@@ -88,8 +87,7 @@ public sealed class CatalogLoader(HttpClient http) : ICatalogLoader
 		}
 		catch (OperationCanceledException)
 		{
-			// Component teardown — silent. Reset so a fresh LoadAsync can run after the
-			// cancelled one (would otherwise leave the loader permanently un-retryable).
+			// Component teardown — silent; reset so a fresh LoadAsync stays possible.
 			Interlocked.Exchange(ref _started, 0);
 			throw;
 		}
@@ -98,8 +96,7 @@ public sealed class CatalogLoader(HttpClient http) : ICatalogLoader
 			Error = ex;
 			SetProgress(new CatalogLoadProgress(CatalogLoadPhase.Failed, 0, 0, null));
 			Log.Error(ex, "Background catalog load failed");
-			// Reset so callers can retry — the idempotency guard at the top is for in-flight
-			// double-LoadAsync, not for "load once, never retry".
+			// Reset so callers can retry; the guard at the top only blocks in-flight double-loads.
 			Interlocked.Exchange(ref _started, 0);
 		}
 	}

--- a/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
+++ b/MtgCsvHelper.BlazorWebAssembly/Pages/MtgCsvProcessor.razor
@@ -196,11 +196,7 @@
 
 	@if (r.Issues.Count > 0)
 	{
-		// Per-row deduplication: a row that ends up dropped (Error) often also collected a
-		// precondition Warning earlier in the pipeline (e.g. SetInfoEnricher's "Set code 'MB1'
-		// not found" + CatalogValidator's "No printing at MB1 #N"). Show only the most-severe
-		// issue per row — the Error already names the failure precisely; the Warning is just
-		// noise once we know the row was dropped. Chip counts are row-based for the same reason.
+		// A dropped row often also collected a precondition Warning; show only the most-severe issue per row (chip counts likewise).
 		var rowsWithErrors = r.Issues
 			.Where(i => i.Severity == IssueSeverity.Error)
 			.Select(i => i.RowNumber)
@@ -433,9 +429,7 @@
 		_detector ??= new FormatDetector([.. CardMapFactory.SupportedConfigs(Config)]);
 		try
 		{
-			// maxAllowedSize is a *whole-file* size cap, not a read window — must be at
-			// least as large as anything we'd accept for conversion, or OpenReadStream
-			// throws and detection silently fails for big files.
+			// maxAllowedSize is a whole-file cap, not a read window — smaller than the file and OpenReadStream throws, silently failing detection.
 			await using var stream = _csvFile.OpenReadStream(maxAllowedSize: MaxFileSize);
 			var detected = await _detector.DetectAsync(stream);
 			if (detected is not null)
@@ -455,8 +449,7 @@
 		}
 	}
 
-	// Keep input ≠ output. When the user picks a value that matches the other select, snap
-	// the other one to the first format in the list that isn't the new value.
+	// Keep input ≠ output: when the pick collides, snap the other select to the first different format.
 	void OnInputFormatChanged(string value)
 	{
 		_selectedInputFormat = value;
@@ -473,10 +466,7 @@
 			_selectedInputFormat = _inputFormats.First(f => f != value);
 	}
 
-	// Imported PhysicalMtgCard objects don't carry the Scryfall Id (the CSV parse only fills
-	// Set/CollectorNumber/Name). We look up the reference printing here to source the image
-	// URL and the canonical Scryfall page link. Returns null for stub rows that don't match
-	// a real printing (e.g. unresolved Cardmarket imports).
+	// Resolves the reference printing behind the image + Scryfall page links; null for stub rows that don't match a real printing.
 	ReferenceCard? ResolveRef(PhysicalMtgCard card)
 	{
 		if (string.IsNullOrEmpty(card.Printing.Set) || string.IsNullOrEmpty(card.Printing.CollectorNumber))

--- a/MtgCsvHelper.BlazorWebAssembly/Program.cs
+++ b/MtgCsvHelper.BlazorWebAssembly/Program.cs
@@ -16,10 +16,7 @@ builder.Services
 		c.SnackbarConfiguration.PositionClass = MudBlazor.Defaults.Classes.Position.BottomRight;
 		c.SnackbarConfiguration.VisibleStateDuration = 4000;
 	})
-	// All Singleton — Blazor WASM has a single root scope per session, and keeping the
-	// catalog loader / its captured HttpClient / the catalog-factory all at the same
-	// (long-lived) lifetime avoids any captive-dependency surprises if this DI graph is
-	// ever ported to a Blazor Server or hybrid project.
+	// All Singleton: one lifetime across loader, its HttpClient, and the factory — no captive-dependency surprises.
 	.AddSingleton<ICatalogLoader, CatalogLoader>()
 	.AddSingleton<Func<IReferenceCardCatalog>>(sp =>
 		() => sp.GetRequiredService<ICatalogLoader>().Catalog
@@ -30,7 +27,5 @@ Log.Logger = new LoggerConfiguration().ReadFrom.Configuration(builder.Configurat
 Log.Information("Hello, Blazor, Serilog online!");
 builder.Logging.AddSerilog();
 
-// Catalog load happens lazily after the shell renders — kicked off from MainLayout, owned by
-// CatalogLoader. See ICatalogLoader for status / progress / error wiring.
-
+// The catalog loads lazily after the shell renders — kicked off from MainLayout, owned by CatalogLoader.
 await builder.Build().RunAsync();

--- a/MtgCsvHelper.BlazorWebAssembly/ScryfallImage.cs
+++ b/MtgCsvHelper.BlazorWebAssembly/ScryfallImage.cs
@@ -10,12 +10,11 @@ public static class ScryfallImage
 {
 	const string CdnBase = "https://cards.scryfall.io";
 
-	/// <summary>Image size — see <c>https://scryfall.com/docs/api/images</c>.</summary>
 	[SuppressMessage("Design", "CA1055:URI-like return values should not be strings", Justification = "Consumed by MudImage.Src and <img src>, both of which take string.")]
-	public static string Url(Guid scryfallId, string size = "normal")
+	public static string Url(Guid scryfallId)
 	{
 		var hex = scryfallId.ToString("D");
-		return $"{CdnBase}/{size}/front/{hex[0]}/{hex[1]}/{hex}.jpg";
+		return $"{CdnBase}/normal/front/{hex[0]}/{hex[1]}/{hex}.jpg";
 	}
 
 	/// <summary>Canonical Scryfall page for a specific printing.</summary>

--- a/MtgCsvHelper.Console/Program.cs
+++ b/MtgCsvHelper.Console/Program.cs
@@ -6,8 +6,7 @@ using Microsoft.Extensions.Hosting;
 using MtgCsvHelper;
 using MtgCsvHelper.Services;
 
-// Load the bundled reference catalog up-front so we can register the pre-loaded instance
-// into DI (avoids sync-over-async in a factory lambda). Bundle ships next to the exe under data/.
+// Pre-load the bundled catalog so DI registers the instance directly (no sync-over-async factory lambda).
 var bundlePath = Path.Combine(AppContext.BaseDirectory, "data", "cards.min.json.gz");
 if (!File.Exists(bundlePath))
 {
@@ -21,10 +20,7 @@ if (!File.Exists(bundlePath))
 await using var bundleStream = File.OpenRead(bundlePath);
 var catalog = await ReferenceCardCatalog.LoadGzipAsync(bundleStream);
 
-// Load appsettings.json from next to the exe, not from the user's cwd. Without this, running
-// the Console from anywhere except its bin output makes config loading silently fail and the
-// "supported formats" list ends up empty (which then surfaces as a confusing "Unsupported format"
-// error even for known formats).
+// Load appsettings.json from next to the exe — from any other cwd, config silently loads empty and every format reads as unsupported.
 IHostBuilder builder = Host
 	.CreateDefaultBuilder(args)
 	.UseContentRoot(AppContext.BaseDirectory)
@@ -38,13 +34,9 @@ IHostBuilder builder = Host
 
 using IHost host = builder.Build();
 
-// Ask the service provider for the configuration abstraction.
 var config = host.Services.GetRequiredService<IConfiguration>();
 
-// Console-specific Serilog setup. The base (MinimumLevel + Debug sink + output template) lives
-// in AppLogging so tests share it; Console layers on Console + File sinks here. Kept in code
-// rather than appsettings.json so the shared appsettings can be linked into Blazor (which uses
-// BrowserConsole instead — see appsettings.Development.json).
+// Console + File sinks layer on the shared AppLogging base; kept in code so the shared appsettings can link into Blazor.
 Log.Logger = AppLogging.CreateDefaultLoggerConfig()
 	.Enrich.FromLogContext()
 	.WriteTo.Console(outputTemplate: AppLogging.DEFAULT_OUTPUT_TEMPLATE)

--- a/MtgCsvHelper.Console/Program.cs
+++ b/MtgCsvHelper.Console/Program.cs
@@ -58,8 +58,7 @@ Parser.Default.ParseArguments<CommandLineOptions>(args)
 	.WithNotParsed(HandleParseError)
 	.WithParsed(RunWithOptions);
 
-Log.Information($"Done. Press Ctrl+C to exit");
-Console.ReadLine();
+Log.Information("Done.");
 
 void RunWithOptions(CommandLineOptions opts)
 {

--- a/MtgCsvHelper.Tests/CardConditionConverterTests.cs
+++ b/MtgCsvHelper.Tests/CardConditionConverterTests.cs
@@ -3,17 +3,13 @@ using MtgCsvHelper.Converters;
 
 namespace MtgCsvHelper.Tests;
 
-// Pins the behaviour for formats whose appsettings.json declares Mint or Excellent as null
-// because they collapse to NearMint on write. The invariant: ambiguous reads resolve to
-// NearMint (not Mint or Excellent), and writes of Mint/Excellent emit the NearMint string.
-//
-// The four affected formats today are Archidekt (Mint + Excellent → NearMint), Moxfield,
-// TopDecked, Deckbox (Excellent → NearMint). TCGPlayer has a different collision pattern
-// (Excellent + Good both → "Lightly Played") and is not covered by this test — see
-// CONVERSION_LIMITATIONS.md for the pre-existing-issue note.
-public class CardConditionConverterTests : BaseTest
+/// <summary>
+/// Pins the null-collapse invariant for formats declaring Mint/Excellent as null: ambiguous reads
+/// resolve to NearMint, and writes of Mint/Excellent emit the NearMint string. TCGPlayer's separate
+/// collision (Excellent + Good → "Lightly Played") is out of scope — see CONVERSION_LIMITATIONS.md.
+/// </summary>
+public class CardConditionConverterTests(ITestOutputHelper output) : BaseTest(output)
 {
-	public CardConditionConverterTests(ITestOutputHelper output) : base(output) { }
 
 	static CardConditionConverter ConverterFor(string? mint, string nearMint, string? excellent) =>
 		new(new ConditionConfiguration(

--- a/MtgCsvHelper.Tests/CardmarketTests.cs
+++ b/MtgCsvHelper.Tests/CardmarketTests.cs
@@ -87,7 +87,7 @@ public class CardmarketTests(CatalogFixture fixture, ITestOutputHelper output) :
 	}
 
 	[Fact]
-	public void ParseWrongFormat_AsCardmarket_ThrowsHeaderValidationException()
+	public async Task ParseWrongFormat_AsCardmarket_ThrowsHeaderValidationException()
 	{
 		// Moxfield-shaped CSV fed to the CARDMARKET handler — the required 'idProduct' / 'groupCount' headers are absent.
 		var csv = "Count,Name,Edition,Collector Number,Foil,Condition,Language,Purchase Price\n"
@@ -95,7 +95,7 @@ public class CardmarketTests(CatalogFixture fixture, ITestOutputHelper output) :
 
 		var act = async () => await Handler().ParseCollectionCsvAsync(CsvStream(csv));
 
-		act.Should().ThrowAsync<HeaderValidationException>();
+		await act.Should().ThrowAsync<HeaderValidationException>();
 	}
 
 	[Fact]

--- a/MtgCsvHelper.Tests/DeckFormatTests.cs
+++ b/MtgCsvHelper.Tests/DeckFormatTests.cs
@@ -5,31 +5,19 @@ namespace MtgCsvHelper.Tests;
 [Collection(CatalogCollection.Name)]
 public class DeckFormatTests(CatalogFixture fixture, ITestOutputHelper output) : ApiBaseTest(fixture, output)
 {
+	public static TheoryData<string> ReadableFormats() => new(CardMapFactory.ReadableFormats);
+	public static TheoryData<string> WritableFormats() => new(CardMapFactory.WritableFormats);
+
 	[Theory]
-	[InlineData("DRAGONSHIELD")]
-	[InlineData("MOXFIELD")]
-	[InlineData("MANABOX")]
-	[InlineData("TOPDECKED")]
-	[InlineData("DECKBOX")]
-	[InlineData("MTGGOLDFISH")]
-	[InlineData("TCGPLAYER")]
-	[InlineData("ARCHIDEKT")]
-	public void GenerateReadMap_ForBidirectionalFormats_Succeeds(string deckFormatName)
+	[MemberData(nameof(ReadableFormats))]
+	public void GenerateReadMap_ForReadableFormats_Succeeds(string deckFormatName)
 	{
 		var map = new CardMapFactory(_config, _catalog).GenerateReadMap(deckFormatName);
 		map.Should().NotBeNull();
 	}
 
 	[Theory]
-	[InlineData("DRAGONSHIELD")]
-	[InlineData("MOXFIELD")]
-	[InlineData("MANABOX")]
-	[InlineData("TOPDECKED")]
-	[InlineData("DECKBOX")]
-	[InlineData("MTGGOLDFISH")]
-	[InlineData("TCGPLAYER")]
-	[InlineData("CARDKINGDOM")]
-	[InlineData("ARCHIDEKT")]
+	[MemberData(nameof(WritableFormats))]
 	public void GenerateWriteMap_ForAllSupportedFormats_Succeeds(string deckFormatName)
 	{
 		var map = new CardMapFactory(_config, _catalog).GenerateWriteMap(deckFormatName);

--- a/MtgCsvHelper.Tests/FaultToleranceTests.cs
+++ b/MtgCsvHelper.Tests/FaultToleranceTests.cs
@@ -92,10 +92,7 @@ public class FaultToleranceTests(CatalogFixture fixture, ITestOutputHelper outpu
 	[Fact]
 	public void NonPositiveCount_RaisesError_RowDropped_WithRawContent()
 	{
-		// Guards the parse-time RawContent capture (not the enricher pipeline). The Count
-		// validation runs inside the GetRecord try-block in MtgCardCsvHandler before the row
-		// reaches any enricher; if csv.Parser.RawRecord isn't captured there too the field is
-		// null on the emitted issue.
+		// Count validation runs in the parse loop before any enricher — RawContent must be captured there too or it's null on the issue.
 		var csv = MoxHeader + "\n"
 			+ "0,Lightning Bolt,M11,149,,Near Mint,English,\n";
 

--- a/MtgCsvHelper.Tests/FormatDetectorTests.cs
+++ b/MtgCsvHelper.Tests/FormatDetectorTests.cs
@@ -15,10 +15,7 @@ public class FormatDetectorTests(ITestOutputHelper output) : BaseTest(output)
 	[InlineData("Quantity,Name,Finish,Condition,Date Added,Language,Purchase Price,Tags,Edition Name,Edition Code,Multiverse Id,Scryfall ID,Collector Number", "ARCHIDEKT")]
 	[InlineData("Card Name,Quantity,ID #,Rarity,Set,Collector #,Premium,Sideboarded,Annotation", "MTGO")]
 	[InlineData("idProduct;groupCount;isFoil;condition;idLanguage;price", "CARDMARKET")]
-	// CARDKINGDOM uses lowercase headers, distinct from any other format in the configured set.
-	// No matching fixture in Resources/SampleCsvs/Collection (the sample file uses Title-Case
-	// headers that don't match the configured map — see appsettings.json) — covering with
-	// an explicit InlineData until #61 fills in proper per-format fixtures.
+	// CARDKINGDOM has no committed fixture (write-only format); its lowercase header is covered inline.
 	[InlineData("quantity,title,edition,foil", "CARDKINGDOM")]
 	// Quoted-header variants — real exports from these sites quote some/all column names.
 	[InlineData("QUANTITY,\"NAME\",SETCODE,\"SETNAME\",\"COLLECTOR NUMBER\",FINISH,PRICE,RARITY,ID,ACQUIRED DATE,ACQUIRED PRICE,LANG,PRICE SALE,SIGNING,ALTERATION,CONDITION,NOTES,TAGS", "TOPDECKED")]
@@ -46,10 +43,7 @@ public class FormatDetectorTests(ITestOutputHelper output) : BaseTest(output)
 		NewDetector().Detect("Quantity,Card Name,Set Code,Set Name,Card Number").Should().Be("DRAGONSHIELD");
 	}
 
-	// Regression: ensure detection works against the real fixture files, including any
-	// quoting / casing quirks of each export. Hand-typed header strings in the theory
-	// above missed that Topdecked and Moxfield quote some columns — only reading the
-	// actual file catches that.
+	// Real fixture files carry the quoting/casing quirks hand-typed headers miss (Topdecked and Moxfield quote some columns).
 	[Theory]
 	[InlineData("dragonshield-collection.csv", "DRAGONSHIELD")]
 	[InlineData("moxfield-haves.csv", "MOXFIELD")]

--- a/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
+++ b/MtgCsvHelper.Tests/MtgCardCsvHandlerTests.cs
@@ -199,9 +199,7 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 	[Fact]
 	public void Mtgo_AllRowsParse_WithCollectorNumberStrippedAndMtgoCodeAliased()
 	{
-		// MTGO fixture has 7 rows of old-set printings (Mirage, Visions, Tempest, Exodus).
-		// Two MTGO-specific quirks the parser handles: collector numbers in "N/M" form
-		// (116/350 → 116) and 2-letter set codes (MI → MIR via the bundled mtgo_code map).
+		// The 7 old-set rows exercise both MTGO quirks: "N/M" collector numbers (116/350 → 116) and 2-letter set codes (MI → MIR).
 		var handler = CreateHandler("MTGO");
 		var result = handler.ParseCollectionCsv($"{COLLECTIONS_FOLDER}/mtgo-collection.csv");
 
@@ -213,8 +211,7 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 		result.Collection.Cards.Select(c => c.Printing.CollectorNumber)
 			.Should().AllSatisfy(n => n.Should().NotContain("/"));
 
-		// MTGO 2-letter codes (MI, VI, TE, EX) must be rewritten to canonical 3-letter Scryfall
-		// codes (MIR, VIS, TMP, EXO) so MTGO → other-format conversions emit the right code.
+		// 2-letter MTGO codes must come out as canonical 3-letter Scryfall codes (MI → MIR) for cross-format conversions.
 		result.Collection.Cards.Should().AllSatisfy(c =>
 			c.Printing.Set.Should().HaveLength(3, "MTGO 2-letter codes should be resolved to canonical Scryfall codes"));
 	}
@@ -222,9 +219,7 @@ public class MtgCardCsvHandlerTests(CatalogFixture fixture, ITestOutputHelper ou
 	[Fact]
 	public void Mtgo_ConvertToMoxfield_EmitsCanonicalSetCodesInOutput()
 	{
-		// End-to-end through the WRITE path: parse MTGO, write to Moxfield, then inspect the
-		// emitted CSV. Catches any regression that bypasses the in-memory canonicalization but
-		// still produces a non-canonical code in the output column.
+		// End-to-end through the write path — catches a regression that canonicalizes in memory but emits a non-canonical code.
 		var reader = CreateHandler("MTGO");
 		var writer = CreateHandler("MOXFIELD");
 

--- a/MtgCsvHelper.Tests/ReferenceCardCatalogTests.cs
+++ b/MtgCsvHelper.Tests/ReferenceCardCatalogTests.cs
@@ -195,9 +195,7 @@ public class ReferenceCardCatalogTests
 		c.IsTokenName("Lightning Bolt").Should().BeFalse();
 	}
 
-	// Guards the split-vs-DFC distinction CardNameConverter relies on: "// " names with layout
-	// = "split" must keep the full name on export, layouts like "transform" should be stripped
-	// to the front face. Adventures don't carry "// " in their Scryfall name so they're n/a here.
+	// Split layouts keep the full "A // B" name on export; transform-like layouts strip to the front face (CardNameConverter relies on this).
 	[Theory]
 	[InlineData("Commit // Memory", "split")]
 	[InlineData("Delver of Secrets // Insectile Aberration", "transform")]

--- a/MtgCsvHelper.Tests/SetInfoEnricherTests.cs
+++ b/MtgCsvHelper.Tests/SetInfoEnricherTests.cs
@@ -8,11 +8,7 @@ public class SetInfoEnricherTests(CatalogFixture fixture)
 {
 	readonly SetInfoEnricher _enricher = new(fixture.Catalog);
 
-	// Guards the "catalog always wins for SetName" invariant relied on by the Deckbox round-trip
-	// path: when a row imports with a non-canonical SetName (e.g. Deckbox's "Extras: Modern
-	// Horizons 2") but a resolvable Set code, the catalog's canonical name takes precedence.
-	// Required so downstream writers (Moxfield, Manabox, …) emit the canonical form regardless of
-	// which CSV the cards came from.
+	// Catalog always wins for SetName: a non-canonical import name (Deckbox "Extras: …") with a resolvable code gets the canonical name, so every writer emits the canonical form.
 	[Fact]
 	public async Task EnrichAsync_NonCanonicalSetName_OverwrittenByCatalog()
 	{
@@ -34,10 +30,7 @@ public class SetInfoEnricherTests(CatalogFixture fixture)
 			because: "the catalog's Scryfall-canonical name must always win over the CSV's value when the set code resolves");
 	}
 
-	// Companion to the test above: when the CSV already carries the Scryfall canonical name
-	// (Moxfield / Manabox / Archidekt / TopDecked all emit canonical names), the catalog
-	// overwrite is a no-op. Documents the intended boundary so the "catalog always wins" rule
-	// can't silently degrade into "catalog overwrites with garbage when name lookup misfires".
+	// Companion boundary: an already-canonical SetName passes through as a no-op overwrite.
 	[Fact]
 	public async Task EnrichAsync_AlreadyCanonicalSetName_PassesThroughUnchanged()
 	{
@@ -59,10 +52,7 @@ public class SetInfoEnricherTests(CatalogFixture fixture)
 			because: "a row that already carries the Scryfall canonical name must come out unchanged");
 	}
 
-	// Diagnostic — pinning the current behavior for an "MB1 + Mystery Booster" row whose
-	// set code is unknown to the catalog. Reported by user: both SetInfoEnricher emits a
-	// warning ("Set code 'MB1' not found") AND CatalogValidator emits an error
-	// ("No printing at MB1 #N"). One issue per row, not two, is the expected UX.
+	// One issue per row: an unknown set code with a CSV-provided name must not warn here on top of CatalogValidator's downstream error.
 	[Fact]
 	public async Task EnrichAsync_UnknownSetCode_WithCsvProvidedSetName_DoesNotWarn()
 	{
@@ -81,7 +71,6 @@ public class SetInfoEnricherTests(CatalogFixture fixture)
 		var issues = new List<ImportIssue>();
 		await _enricher.EnrichAsync([row], issues, CancellationToken.None);
 
-		issues.Should().BeEmpty(
-			because: "the CSV supplied both a set code and a set name; SetInfoEnricher's role is to canonicalize against the catalog, not to flag every unknown set — CatalogValidator's downstream lookup will already emit a precise (Set, CollectorNumber) error.");
+		issues.Should().BeEmpty(because: "CatalogValidator's downstream lookup already emits the precise error for this row");
 	}
 }

--- a/MtgCsvHelper.Tests/TestCollectionFixtureTests.cs
+++ b/MtgCsvHelper.Tests/TestCollectionFixtureTests.cs
@@ -1,14 +1,11 @@
 namespace MtgCsvHelper.Tests;
 
-// Fixture suffixes wired to theories in this class:
-//   *-real-export.csv                  → all rows parse, Cards.Count == data-row count
-//   *-rejected.csv                     → all rows error, no cards land
-//   *-mixed-warnings-and-errors.csv    → Cards.Count + ErrorCount == data-row count
-//   *-field-fidelity.csv               → driven by MtgCardCsvHandlerTests (not this class)
-//
-// Other fixtures in Tests/ (warnings-only.csv, wrong-format-headers.csv,
-// blank-and-delimiter-rows.csv) are deliberately not wired — they're manual-testing
-// inputs for eyeballing Console / Blazor UX with edge-case CSVs.
+/// <summary>
+/// Fixture suffixes wired to theories here: <c>*-real-export.csv</c> (all rows parse),
+/// <c>*-rejected.csv</c> (all rows error), <c>*-mixed-warnings-and-errors.csv</c> (cards + errors
+/// account for every row). <c>*-field-fidelity.csv</c> is driven by MtgCardCsvHandlerTests; the
+/// remaining fixtures in Tests/ are unwired manual-testing inputs for Console / Blazor UX.
+/// </summary>
 [Collection(CatalogCollection.Name)]
 public class TestCollectionFixtureTests(CatalogFixture fixture, ITestOutputHelper output) : ApiBaseTest(fixture, output)
 {

--- a/MtgCsvHelper/CardMapFactory.cs
+++ b/MtgCsvHelper/CardMapFactory.cs
@@ -59,10 +59,7 @@ public class CardMapFactory(IConfiguration config, IReferenceCardCatalog catalog
 		return new PhysicalCardMap(cfg, catalog);
 	}
 
-	// Throwing counterpart to GetFormatConfig (matches the GetService/GetRequiredService convention).
-	// Two distinct failure modes, in order of precondition:
-	//   1. _formatConfigs is empty       — appsettings.json never loaded; system is misconfigured.
-	//   2. format isn't in _formatConfigs — caller asked for something we don't know.
+	// Throwing counterpart to GetFormatConfig; distinguishes "no config loaded at all" from "unknown format".
 	FormatConfig GetRequiredFormatConfig(string format)
 	{
 		if (_formatConfigs.Count == 0)

--- a/MtgCsvHelper/CardMapFactory.cs
+++ b/MtgCsvHelper/CardMapFactory.cs
@@ -9,7 +9,6 @@ public class CardMapFactory(IConfiguration config, IReferenceCardCatalog catalog
 	readonly List<FormatConfig> _formatConfigs = From(config).ToList();
 
 	public static IReadOnlyList<string> Supported { get; } = ["MOXFIELD", "DRAGONSHIELD", "MANABOX", "TOPDECKED", "DECKBOX", "CARDKINGDOM", "MTGGOLDFISH", "TCGPLAYER", "CARDMARKET", "ARCHIDEKT", "MTGO"];
-	public static IReadOnlyList<string> NotYetFullySupported { get; } = ["URZAGATHERER"];
 
 	// Write-only / read-only format sets; internal so tests derive expectations from the same source of truth.
 	internal static readonly IReadOnlySet<string> WriteOnlyFormats = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CARDKINGDOM" };

--- a/MtgCsvHelper/Converters/CardConditionConverter.cs
+++ b/MtgCsvHelper/Converters/CardConditionConverter.cs
@@ -12,10 +12,7 @@ public class CardConditionConverter(ConditionConfiguration configuration) : ITyp
 		// Blank means the export carries no condition info — not a vocabulary error.
 		if (string.IsNullOrWhiteSpace(text)) { return CardCondition.Unknown; }
 
-		// Duplicate-string collisions are handled at the config level: formats whose Mint or
-		// Excellent collapses to the same string as NearMint declare those fields as `null` in
-		// appsettings.json, so only the NearMint arm matches and switch order is irrelevant.
-		// See CardConditionConverterTests.AmbiguousString_ResolvesToNearMint for the invariant.
+		// Formats whose Mint/Excellent share NearMint's string declare them null, so only the NearMint arm matches — order-independent.
 #pragma warning disable format
 		return text switch
 		{

--- a/MtgCsvHelper/Converters/CollectorNumberConverter.cs
+++ b/MtgCsvHelper/Converters/CollectorNumberConverter.cs
@@ -3,10 +3,7 @@ using CsvHelper.TypeConversion;
 
 namespace MtgCsvHelper.Converters;
 
-// MTGO emits collector numbers as "N/M" (e.g. "116/350") where M is the set total.
-// Strip the suffix on read; all other formats pass through unchanged since "/" doesn't
-// appear in Scryfall collector numbers. Write side preserves whatever's in the model
-// (we don't know the set total, so MTGO round-trips will emit just "N").
+// Strips MTGO's "/set-total" suffix ("116/350" → "116") on read; a no-op for every other format since Scryfall numbers never contain "/".
 public class CollectorNumberConverter : StringConverter
 {
 	public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData) =>

--- a/MtgCsvHelper/Converters/DeckboxCodeReadConverter.cs
+++ b/MtgCsvHelper/Converters/DeckboxCodeReadConverter.cs
@@ -3,10 +3,7 @@ using CsvHelper.TypeConversion;
 
 namespace MtgCsvHelper.Converters;
 
-// On READ from a Deckbox CSV, translates Deckbox-internal Edition Codes (`ex_127`, `pp_neo`)
-// to the Scryfall codes the catalog can resolve (TMH2, PNEO). Pass-through for codes already
-// in Scryfall form. No write-side override is needed — Deckbox import accepts Scryfall codes,
-// so the inherited DefaultTypeConverter behavior (stringify, "" for null) is correct on emit.
+// Read side translates Deckbox-internal Edition Codes (ex_127, pp_neo) to Scryfall codes; writes inherit pass-through since Deckbox accepts Scryfall codes.
 internal sealed class DeckboxCodeReadConverter(IReadOnlyDictionary<string, string> codeAliases) : DefaultTypeConverter
 {
 	public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)

--- a/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
+++ b/MtgCsvHelper/Enrichment/CardmarketIdEnricher.cs
@@ -13,8 +13,7 @@ public sealed class CardmarketIdEnricher(ICardmarketResolver resolver) : IEnrich
 {
 	public async Task EnrichAsync(List<ParsedRow> rows, ICollection<ImportIssue> issues, CancellationToken ct)
 	{
-		// CardMarketId is `int` (not `int?`) in the Scryfall library, so 0 acts as the "unset" sentinel —
-		// real cardmarket_ids are always positive in Scryfall data.
+		// CardMarketId is `int` (not `int?`) in the Scryfall library, so 0 is the unset sentinel (real ids are positive).
 		var pending = new List<(int Index, int Id)>();
 		for (int i = 0; i < rows.Count; i++)
 		{
@@ -30,12 +29,7 @@ public sealed class CardmarketIdEnricher(ICardmarketResolver resolver) : IEnrich
 		var ids = pending.Select(p => p.Id).Distinct().ToList();
 		var resolved = await resolver.ResolveAsync(ids, ct);
 
-		// Walk in reverse so RemoveAt doesn't shift positions we still need to visit. Invariant:
-		// pending was built by walking rows forward, so its Index values are strictly ascending —
-		// reverse iteration here processes rows high-to-low, and each RemoveAt(i) only shifts
-		// positions we've already visited. Duplicate CardMarketIds across rows are handled
-		// correctly: each row has its own entry in `pending` and both look up the same `full`
-		// record below (TryGetValue is idempotent).
+		// Reverse: pending indices ascend, so each RemoveAt only shifts positions already visited.
 		for (int k = pending.Count - 1; k >= 0; k--)
 		{
 			var (i, id) = pending[k];
@@ -50,10 +44,7 @@ public sealed class CardmarketIdEnricher(ICardmarketResolver resolver) : IEnrich
 			}
 			else
 			{
-				// Without a name/set, we can't write a meaningful row — drop the card.
-				// This is data loss (Error), not just degraded fidelity (Warning).
-				// One error per affected row (not per distinct ID), so duplicate-ID inputs that
-				// fail to resolve produce one issue per row — keeps row-level traceability.
+				// No name/set means no meaningful output row — data loss, so one Error per row and drop.
 				issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
 					$"Cardmarket ID {id} not found in Scryfall data — card skipped",
 					RawContent: row.RawContent));

--- a/MtgCsvHelper/FormatConfig.cs
+++ b/MtgCsvHelper/FormatConfig.cs
@@ -5,9 +5,7 @@ public record FormatConfig(
 	string Quantity,
 	// The site's full native header set in the site's exact column order; the writer emits every declared column, blank when unmodeled. Null = modeled columns only.
 	string[]? Columns = null,
-	// Either CardName or CardmarketId (or in the future another card-identifier kind) must be set.
-	// Most formats identify cards by name + set; Cardmarket identifies by its internal product ID and
-	// requires Scryfall reverse-lookup to fill in name/set/etc. during enrichment.
+	// Either CardName or CardmarketId must be set; Cardmarket identifies by product id, resolved via Scryfall during enrichment.
 	CardNameConfiguration? CardName = null,
 	string? CardmarketId = null,
 	string? SetNumber = null,
@@ -25,13 +23,9 @@ public record FormatConfig(
 	DateBoughtConfiguration? DateBought = null,
 	string? FolderName = null,
 	string? TradeQuantity = null,
-	// True if the importer rejects rows with null cells in declared columns (Dragon Shield).
-	// Triggers a pre-write defaulting pass that fills nulls. Coupling: also expects
-	// PriceBought to be configured (its Currency drives the default price) and a
-	// DefaultFolderName to be set.
+	// Importer rejects null cells (Dragon Shield): triggers a pre-write defaulting pass using PriceBought's currency and DefaultFolderName.
 	bool RequiresWriteDefaults = false,
-	// Folder label stamped on rows whose Folder is null/empty when RequiresWriteDefaults
-	// is true. No effect otherwise.
+	// Folder stamped on null/empty Folder cells when RequiresWriteDefaults is set; no effect otherwise.
 	string DefaultFolderName = "Imported",
 	// CSV delimiter. Most sites use comma; Cardmarket exports use semicolon.
 	string Delimiter = ","
@@ -50,8 +44,7 @@ public record FormatConfig(
 	}
 };
 
-// Shared shape for the rich sub-record configurations: all expose the CSV header they bind to.
-// Lets the map base class register them generically without per-type branching.
+// Shared shape for the rich sub-configs: exposing the bound CSV header lets the map base class register them generically.
 public interface IHeaderConfig
 {
 	string HeaderName { get; }
@@ -68,10 +61,7 @@ public record FinishConfiguration(
 	string Normal,
 	string? Etched = null) : IHeaderConfig;
 
-// Mint and Excellent are nullable so a format with no separate tier for them can declare
-// `null` instead of duplicating another condition's string. The write-side falls back to
-// NearMint when these are null; the read-side simply doesn't match (CsvMatch.MatchesConfig
-// returns false for null), so duplicate-string collisions don't depend on switch arm order.
+// Mint/Excellent are nullable: writes fall back to NearMint, reads simply don't match — so duplicate-string collisions don't depend on switch arm order.
 public record ConditionConfiguration(
 	string HeaderName,
 	string NearMint,
@@ -113,10 +103,7 @@ public record RarityConfiguration(
 	string Mythic,
 	string Bonus) : IHeaderConfig;
 
-// Formats is an ordered list passed straight to CsvHelper's TypeConverterOption.Format(...):
-// the FIRST entry is used for writes, ALL entries are tried in order on read. Lets a format
-// emit a canonical ISO date but still parse a vendor's historical export shape (e.g. Dragon
-// Shield's own exports use M/d/yyyy alongside the yyyy-MM-dd it accepts on import).
+// Ordered list for CsvHelper's TypeConverterOption.Format: the first entry writes, all entries are tried on read (vendors' historical export shapes).
 public record DateBoughtConfiguration(
 	string HeaderName,
 	string[]? Formats = null) : IHeaderConfig

--- a/MtgCsvHelper/FormatDetector.cs
+++ b/MtgCsvHelper/FormatDetector.cs
@@ -9,10 +9,7 @@ namespace MtgCsvHelper;
 public sealed class FormatDetector
 {
 	readonly IReadOnlyList<FormatConfig> _formats;
-	// 2 was chosen empirically: every real-world format in the bundled appsettings has at
-	// least 2 column names that no other format shares at the same casing, making accidental
-	// 2-hit collisions on unrelated CSVs unlikely. If a new format with very generic header
-	// names gets added (e.g. "Name,Set"), revisit.
+	// Empirical: every bundled format has ≥2 uniquely-cased column names; revisit if a very generic format gets added.
 	const int MinMatchesForConfidence = 2;
 
 	public FormatDetector(IReadOnlyList<FormatConfig> formats) => _formats = formats;
@@ -50,16 +47,10 @@ public sealed class FormatDetector
 		foreach (var fmt in _formats)
 		{
 			var configured = HeadersOf(fmt).ToList();
-			// Many exports quote header names (e.g. Topdecked: QUANTITY,"NAME",SETCODE,…) so strip
-			// surrounding quotes before comparing — otherwise `"NAME"` wouldn't match `NAME`.
+			// Strip surrounding quotes before comparing — many exports quote header names (Topdecked: QUANTITY,"NAME",…).
 			var actual = headerLine.Split(fmt.Delimiter).Select(h => h.Trim().Trim('"')).ToHashSet();
 			var hits = configured.Count(h => actual.Contains(h));
-			// Strict improvement OR same score but tighter format (fewer extra unused headers
-			// would indicate a more specific match). Ties beyond that fall back to iteration
-			// order — if two formats end up with the same hit count *and* the same configured
-			// column count, first-in-list wins silently. The current configured formats are
-			// distinct enough that this doesn't happen; reconsider if a new format gets added
-			// whose header set is a near-duplicate of an existing one.
+			// Prefer more hits, then fewer configured columns (tighter format); remaining ties fall to iteration order.
 			if (hits > bestScore || (hits == bestScore && configured.Count < bestConfiguredCount))
 			{
 				bestScore = hits;
@@ -71,9 +62,7 @@ public sealed class FormatDetector
 		return bestScore >= MinMatchesForConfidence ? bestName : null;
 	}
 
-	// Reads the first useful CSV header line, skipping the optional "sep=," marker that
-	// some exports prepend (e.g. DragonShield writes `"sep=,"` — quoted, so we trim a
-	// leading quote before testing).
+	// First useful header line, skipping the optional (possibly quoted) "sep=" marker some exports prepend.
 	static string? ReadHeader(StreamReader reader)
 	{
 		var line = reader.ReadLine();
@@ -91,10 +80,7 @@ public sealed class FormatDetector
 	static bool IsSepMarker(string? line) =>
 		line is not null && line.TrimStart('"').StartsWith("sep=", StringComparison.OrdinalIgnoreCase);
 
-	// Hand-maintained whitelist of header-bearing fields on FormatConfig. Must be kept in
-	// sync with the record's properties — adding a new header field there without listing it
-	// here silently weakens detection accuracy for that format (no compile error). FormatConfig
-	// is short and rarely edited, so the manual coupling is acceptable; revisit if it grows.
+	// Hand-maintained whitelist: a new header-bearing field on FormatConfig must be added here or its detection signal is silently lost.
 	static IEnumerable<string> HeadersOf(FormatConfig f)
 	{
 		yield return f.Quantity;

--- a/MtgCsvHelper/Maps/PhysicalCardMap.cs
+++ b/MtgCsvHelper/Maps/PhysicalCardMap.cs
@@ -12,10 +12,7 @@ public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 {
 	public PhysicalCardMap(FormatConfig cfg, IReferenceCardCatalog catalog)
 	{
-		// Explicit indices override CsvHelper's clustering of nested-member maps
-		// (Printing.Name, Printing.Set, …) — registration order alone interleaves
-		// columns wrong. Unmapped indices are skipped on write, so gaps are fine.
-
+		// Explicit indices override CsvHelper's clustering of nested-member maps (registration order alone interleaves columns wrong); unmapped indices are skipped on write.
 		if (cfg.FolderName is not null) { Map(c => c.Folder).Name(cfg.FolderName).Index(0).TypeConverter<EmptyAsNullStringConverter>(); }
 
 		Map(c => c.Count).Name(cfg.Quantity).Index(1);
@@ -31,14 +28,11 @@ public class PhysicalCardMap : ClassMap<PhysicalMtgCard>
 		}
 		if (cfg.CardmarketId is not null)
 		{
-			// Stub Card object: only CardMarketId is filled here; name/set/etc. get resolved
-			// later in MtgCardCsvHandler.EnrichByCardmarketIdAsync via batched Scryfall lookup.
+			// Stub Card: only CardMarketId is set here; CardmarketIdEnricher resolves the rest via batched Scryfall lookup.
 			Map(c => c.Printing.CardMarketId).Name(cfg.CardmarketId).Index(3);
 		}
 
-		// At least one of SetCode / SetName is expected per format (sites differ on which they include).
-		// CollectorNumberConverter is applied universally (not MTGO-specific) — it's a no-op for any
-		// collector number without a "/", and "/" doesn't appear in Scryfall data.
+		// CollectorNumberConverter is applied universally: a no-op for numbers without "/", which Scryfall data never contains.
 		var setCodeMap = MapOptional(c => c.Printing.Set, cfg.SetCode);
 		if (setCodeMap is not null) { ConfigureSetCode(setCodeMap.Index(4)); }
 		var setNameMap = MapOptional(c => c.Printing.SetName, cfg.SetName);

--- a/MtgCsvHelper/Models/Currency.cs
+++ b/MtgCsvHelper/Models/Currency.cs
@@ -18,8 +18,6 @@ public record Currency(string Symbol, string ShortName, string LongName, NumberF
 	public static readonly Currency EUR = new("€", "EUR", "Euro", EUR_WITH_DOT());
 	public static readonly Currency USD = new("$", "USD", "US Dollar", CultureInfo.CreateSpecificCulture("en-US").NumberFormat);
 
-	public static readonly List<Currency> SupportedCurrencies = [EUR, USD];
-
 	public static Currency FromString(string? input) => input switch
 	{
 		nameof(EUR) => EUR,

--- a/MtgCsvHelper/Models/MtgCard.cs
+++ b/MtgCsvHelper/Models/MtgCard.cs
@@ -1,6 +1,0 @@
-﻿namespace MtgCsvHelper.Models;
-
-public record MtgCard
-{
-	public string Name { get; set; } = "Unknown Card";
-}

--- a/MtgCsvHelper/Models/PhysicalMtgCard.cs
+++ b/MtgCsvHelper/Models/PhysicalMtgCard.cs
@@ -4,7 +4,7 @@ namespace MtgCsvHelper.Models;
 
 // Property order follows PhysicalCardMap's CSV index order (Folder, Count, TradeQuantity,
 // Printing (Name/Set/SetName/CollectorNumber), Condition, Finish, Language, PriceBought,
-// DateBought). TradeListed has no CSV column today and sits at the end.
+// DateBought).
 public record PhysicalMtgCard
 {
 	// TODO: Folder and TradeQuantity are importer-presentation metadata, not card identity.
@@ -28,8 +28,6 @@ public record PhysicalMtgCard
 
 	public DateTime? DateBought { get; init; }
 
-	public bool? TradeListed { get; init; }
-
-	// No format maps a rarity column; backfilled from the catalog once the printing resolves.
+	// Backfilled from the catalog once the printing resolves; formats with a rarity column also map it.
 	public CardRarity Rarity { get; init; } = CardRarity.Unknown;
 }

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -16,13 +16,7 @@ public class MtgCardCsvHandler
 	{
 		_format = format;
 		_factory = new CardMapFactory(config, catalog);
-		// Order matches the prior inline implementation:
-		// 1. SetInfo + Validator run on non-stub rows (Cardmarket stubs have Name="" and are
-		//    skipped by both via their leading null-name guards).
-		// 2. CardmarketIdEnricher runs last, resolving stubs from the Scryfall network/catalog.
-		// Cardmarket-resolved cards intentionally bypass CatalogValidator: the resolver's data
-		// IS Scryfall data, so validating it against our possibly-stale local bundle would drop
-		// legitimate cards released after our last bundle refresh.
+		// Cardmarket stubs (Name="") pass through SetInfo + Validator untouched; CardmarketIdEnricher resolves them last from live Scryfall data, which outranks our bundle.
 		_pipeline =
 		[
 			new SetInfoEnricher(catalog),
@@ -31,8 +25,7 @@ public class MtgCardCsvHandler
 		];
 	}
 
-	// Sync wrappers — fine for non-Blazor callers and for formats that don't need network I/O.
-	// Cardmarket forces async (Scryfall lookups), so the sync path blocks on the async path.
+	// Sync wrappers for non-Blazor callers; they block on the async path (Cardmarket forces async via Scryfall lookups).
 	public ParseResult ParseCollectionCsv(string csvFilePath) => ParseCollectionCsvAsync(csvFilePath).GetAwaiter().GetResult();
 	public ParseResult ParseCollectionCsv(Stream csvStream) => ParseCollectionCsvAsync(csvStream).GetAwaiter().GetResult();
 
@@ -120,18 +113,15 @@ public class MtgCardCsvHandler
 			await enricher.EnrichAsync(rows, issues, ct);
 		}
 
-		// Pipeline stages emit issues in mixed order (parse loop ascending, PerCardEnricher
-		// reverse iteration descending, batch enrichers ascending). Sort by RowNumber once at
-		// the exit so consumers always see ascending row order.
+		// Pipeline stages emit issues in mixed row order; sort once at the exit.
 		var collection = new Collection { Name = $"Import {_format}, Date: {DateTime.Now}", Cards = [.. rows.Select(r => r.Card)] };
 		Log.Debug(collection.GenerateSummary());
 		return new ParseResult(collection, [.. issues.OrderBy(i => i.RowNumber)]);
 
 		static void CheckIfFirstLineCanBeIgnored(StreamReader stream)
 		{
-			// "Peek" into the first row, and if it is not a separator info row, reset the stream. (Found no more elegant way to do this)
+			// Peek at the first line; rewind unless it's a "sep=" marker row.
 			var hasSeparatorInfoFirstLine = stream.ReadLine()?.Contains("sep=") ?? false;
-			// Reset the stream to the original state if the first line is not a separator info line
 			if (!hasSeparatorInfoFirstLine)
 			{
 				stream.BaseStream.Position = 0;
@@ -153,8 +143,7 @@ public class MtgCardCsvHandler
 		var cfg = _factory.GetFormatConfig(_format)
 			?? throw new InvalidOperationException($"Format '{_format}' configuration not found.");
 
-		// Project into new records when defaulting so the caller's cards stay immutable —
-		// avoids the second-write-sees-first-write-defaults hazard.
+		// Project new records when defaulting so the caller's cards stay immutable across writes.
 		var rowsToWrite = cfg.RequiresWriteDefaults ? ApplyWriteDefaults(cards, cfg) : cards;
 
 		if (cfg.Columns is null)

--- a/MtgCsvHelper/MtgCardCsvHandler.cs
+++ b/MtgCsvHelper/MtgCardCsvHandler.cs
@@ -143,7 +143,7 @@ public class MtgCardCsvHandler
 	public void WriteCollectionCsv(IList<PhysicalMtgCard> cards, string? outputFileName = null)
 	{
 		outputFileName ??= $"{_format.ToLower()}-output-{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv";
-		Log.Information($"Writing {cards.Sum(c => c.Count)} cards ({cards.Count} unique) cards to {outputFileName}");
+		Log.Information($"Writing {cards.Sum(c => c.Count)} cards ({cards.Count} unique) to {outputFileName}");
 		using var stream = File.Create(outputFileName);
 		WriteCollectionCsv(cards, stream);
 	}

--- a/MtgCsvHelper/ReferenceCard.cs
+++ b/MtgCsvHelper/ReferenceCard.cs
@@ -39,11 +39,7 @@ public sealed record ReferenceCard(
 	// Unknown in bundles generated before the field existed.
 	CardRarity Rarity = CardRarity.Unknown)
 {
-	// Normalized at construction: Set and MtgoCode are uppercased for any primary-constructor
-	// invocation (factory, JSON deserialization, direct ctor in tests). The catalog's lookup
-	// invariants depend on uppercase storage. Note: `with { Set = "mir" }` would bypass the
-	// initializer; no such callers exist today, but a future one would need to uppercase
-	// manually or this can be upgraded to a normalizing init setter.
+	// Uppercased at construction — the catalog's lookup invariants depend on it; a `with { Set = … }` would bypass this initializer.
 	public string Set { get; init; } = Set.ToUpperInvariant();
 	public string? MtgoCode { get; init; } = MtgoCode?.ToUpperInvariant();
 

--- a/MtgCsvHelper/ReferenceCardCatalog.cs
+++ b/MtgCsvHelper/ReferenceCardCatalog.cs
@@ -11,11 +11,7 @@ namespace MtgCsvHelper;
 /// </summary>
 public sealed class ReferenceCardCatalog : IReferenceCardCatalog
 {
-	// "Double-faced" detection matches the existing CachedMtgApi behavior exactly: any printing
-	// whose Scryfall `name` contains " // ". This catches transform, modal_dfc, split, meld
-	// pairs, and double-faced tokens uniformly, while correctly EXCLUDING adventures (which
-	// only carry the creature-face name in `name`) and other layouts where the back-face name
-	// is hidden in `card_faces` rather than the top-level `name`.
+	// A " // " in the top-level Scryfall name marks a DFC (transform, modal, split, meld); adventures keep only the creature face there and are correctly excluded.
 	const string DoubleFacedSeparator = " // ";
 
 	static readonly HashSet<string> TokenLayouts = new(StringComparer.OrdinalIgnoreCase)

--- a/tools/MtgCsvHelper.RefreshReferenceData/DeckboxAliasesGenerator.cs
+++ b/tools/MtgCsvHelper.RefreshReferenceData/DeckboxAliasesGenerator.cs
@@ -43,27 +43,13 @@ internal static class DeckboxAliasesGenerator
 		var sets = catalog.GetSets(); // Set code (UPPER) → Scryfall canonical name
 		Console.WriteLine($"  {sets.Count} Scryfall sets loaded.");
 
-		// Two output maps emitted in lockstep:
-		//   - SetCodeToDeckboxName  (deckbox-set-aliases.json):  Scryfall code → Deckbox edition name
-		//     Used on the WRITE side to emit the Edition column with Deckbox's curated names.
-		//   - DeckboxCodeToSetCode  (deckbox-code-aliases.json): Deckbox edition code → Scryfall code
-		//     Used on the READ side to translate Deckbox-internal codes like `ex_127` into the
-		//     Scryfall codes the catalog can resolve. Only emitted when the codes differ.
+		// deckbox-code-aliases.json (read side): Deckbox edition code → Scryfall code, emitted only when they differ.
 		var codeAliases = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-		// Build the alias map across three Deckbox row shapes:
-		//   1. Canonical regular sets — Deckbox code matches esym (e.g. AFC/afc, M14/m14).
-		//      Map esym (upper) → Deckbox name. Skip if Deckbox already matches Scryfall.
-		//   2. "Promo Pack: …" rows — Deckbox code like PP_NEO, esym is the parent (neo).
-		//      The corresponding Scryfall set is `p<esym>` (PNEO, "Kamigawa: Neon Dynasty Promos").
-		//   3. "Extras: …" rows (tokens) — Deckbox code like EX_45, esym is the parent.
-		//      The corresponding Scryfall set is `t<esym>` (TM14, "Magic 2014 Tokens").
-		// Sub-products that don't fit any of these (OAFC, OS_*, AFR_AMP, …) are skipped — they
-		// reuse a parent set's esym but don't correspond to a distinct Scryfall set we'd ever
-		// emit.
-		// Reverse name index. Scryfall set names are unique in our catalog so a Dictionary suffices.
+		// Reverse name index; Scryfall set names are unique in our catalog.
 		var scryfallCodeByName = sets.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
 
+		// deckbox-set-aliases.json (write side): Scryfall code → Deckbox's curated edition name.
 		var aliases = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 		int aliasedByName = 0, aliasedByCode = 0, aliasedPromo = 0, aliasedToken = 0;
 		int skippedExactMatch = 0, skippedSubProduct = 0;
@@ -71,8 +57,7 @@ internal static class DeckboxAliasesGenerator
 		{
 			var name = WebUtility.HtmlDecode(e.DeckboxName);
 
-			// 1. Exact-name match — most reliable, catches legacy-code cases (1E↔LEA, AL↔ALL,
-			//    PLIST↔PLST) where the names agree but Deckbox uses old codes.
+			// 1. Exact-name match — most reliable; catches legacy codes (1E↔LEA, AL↔ALL, PLIST↔PLST) where names agree.
 			if (scryfallCodeByName.TryGetValue(name, out var matchedByName))
 			{
 				if (!string.Equals(e.DeckboxCode, matchedByName, StringComparison.OrdinalIgnoreCase))
@@ -116,10 +101,7 @@ internal static class DeckboxAliasesGenerator
 				}
 			}
 
-			// 4. Deckbox code matches a Scryfall code → Scryfall set exists but Deckbox renamed it
-			//    ("Magic 2014" → "Magic 2014 Core Set", "Forgotten Realms Commander" → "Adventures
-			//    in the Forgotten Realms Commander"). Emit a name alias; codes already agree so no
-			//    code alias needed.
+			// 4. Codes agree but Deckbox renamed the set ("Magic 2014" → "Magic 2014 Core Set") — name alias only.
 			var deckboxUpper = e.DeckboxCode.ToUpperInvariant();
 			if (sets.TryGetValue(deckboxUpper, out var scryfallNameByCode)
 				&& !string.Equals(scryfallNameByCode, name, StringComparison.Ordinal))
@@ -129,14 +111,11 @@ internal static class DeckboxAliasesGenerator
 				continue;
 			}
 
-			// 5. Sub-products (OAFC, AFR_AMP, …) and Deckbox-only editions (Summer of Magic) fall
-			//    through. Don't trust esym alone — it's the set *symbol*, which Deckbox reuses for
-			//    arbitrary promos and box-topper variants that aren't the parent set.
+			// 5. Sub-products (OAFC, AFR_AMP, …) and Deckbox-only editions fall through; esym alone is untrustworthy (reused for arbitrary promos).
 			skippedSubProduct++;
 		}
 
-		// 4. "Love your LGS" is a one-to-many: a single Deckbox edition that aggregates every
-		//    Scryfall PLGYY set. Map them all to the same Deckbox name.
+		// "Love your LGS" aggregates every Scryfall PLGYY set under one Deckbox edition — map them all to its name.
 		var lgs = entries.FirstOrDefault(e => e.DeckboxName.Equals("Love your LGS", StringComparison.Ordinal));
 		int aliasedLgs = 0;
 		if (lgs is not null)


### PR DESCRIPTION
## Summary

First installment of the codebase-wide simplicity review (three parallel review agents swept the library, front ends, tools, and tests): the high-confidence tiers — defect fixes, dead-code deletions, and the comment sweep. The deeper duplication/design findings (shared header-mismatch helper, `LanguageConverter` collapse, Blazor render-path cleanups, test consolidation) are a separate follow-up.

## Defect fixes (`1d6621a`)

- **Vacuous test**: `CardmarketTests`' `ThrowAsync` assertion was never awaited inside a `void` test — a missing `HeaderValidationException` passed silently.
- **Drifted format lists**: `DeckFormatTests` hand-listed formats; MTGO and CARDMARKET were never map-tested. Theories now derive from `CardMapFactory.ReadableFormats` / `WritableFormats` (+3 tests).
- **Console hang**: the trailing `Console.ReadLine()` waited for Enter while claiming "Press Ctrl+C", and hung any scripted invocation.
- Doubled "cards" in the collection-write log message.

## Dead code (`e4f77b3`)

`Models/MtgCard.cs` (zero references), `PhysicalMtgCard.TradeListed` (no format maps it), `CardMapFactory.NotYetFullySupported`, `Currency.SupportedCurrencies` (both zero readers), and `ScryfallImage.Url`'s speculative `size` parameter (single call site, always default).

## Comment sweep (`c288398`)

~30 multi-line `//` blocks compressed to one line (or `///` xmldoc for genuinely multi-fact class summaries), per the one-line convention. Includes removing an issue reference (#61) from a comment, fixing two stale references (`EnrichByCardmarketIdAsync` no longer exists; "imported cards don't carry the Scryfall Id" hasn't been true since 1.5.0), and replacing the rotted `DeckboxAliasesGenerator` preamble (claimed three row shapes, the code has five; duplicated step numbering) with per-branch one-liners.

## Verification

294 tests pass. No behavior changes outside the four defect fixes; the comment sweep and deletions are inert by construction.
