### PR TITLE
Keep non-English rows whose localized name mismatches the catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Unreleased work targets the next minor version once a coherent feature set is re
 
 ## [Unreleased]
 
+### Fixed
+
+- **Non-English rows are no longer dropped over their localized card name** ([#103](https://github.com/StepKie/MtgCsvHelper/issues/103)). When a row's `(Set, Collector#)` resolves to a printing but the localized name (e.g. Italian `Fulmine`) doesn't match the English-only catalog, the row is now kept with the catalog's English name and a Warning, instead of being skipped as a name-mismatch error. Applies only to rows whose Language column explicitly says non-English; English rows keep the strict corruption guard.
+
 ### Changed
 
 - **Exports match each site's native column layout** ([#134](https://github.com/StepKie/MtgCsvHelper/issues/134)). Every writable format now emits the site's full header set in the site's exact column order — instead of only the modeled columns in our own order. Strict, order-sensitive importers (Archidekt, TCGplayer) accept the files, and they diff cleanly against real site exports. Catalog-derived columns are filled (rarity, Multiverse Id, TCGplayer product id — extending the Scryfall id from 1.5.0); the rest are left blank. The native layout is declared per format in `appsettings.json` and anchored to a captured export by test.

--- a/MtgCsvHelper.Tests/CatalogValidatorTests.cs
+++ b/MtgCsvHelper.Tests/CatalogValidatorTests.cs
@@ -13,10 +13,11 @@ public class CatalogValidatorTests(CatalogFixture fixture)
 	const string SharedFrontNumber = "15";
 	const string SharedFront = "Monster";
 
-	static ParsedRow Row(string name, string set, string collectorNumber) =>
+	static ParsedRow Row(string name, string set, string collectorNumber, string? language = null) =>
 		new(new PhysicalMtgCard
 		{
 			Count = 1,
+			Language = language,
 			Printing = new Card { Name = name, Set = set, CollectorNumber = collectorNumber, SetName = "" },
 		}, RowNumber: 1);
 
@@ -94,6 +95,26 @@ public class CatalogValidatorTests(CatalogFixture fixture)
 	public async Task WrongName_AtValidSetAndNumber_IsDropped()
 	{
 		var (kept, issues) = await Validate(Row("Lightning Bolt", SharedFrontSet, SharedFrontNumber));
+
+		kept.Should().BeEmpty();
+		issues.Should().ContainSingle().Which.Severity.Should().Be(IssueSeverity.Error);
+	}
+
+	// The catalog is English-only, so a localized name can never match; the resolved (Set, #) identifies the printing.
+	[Fact]
+	public async Task NonEnglishRow_NameMismatch_IsKeptWithEnglishName_AndWarning()
+	{
+		var canonical = fixture.Catalog.FindBySetAndCollectorNumber("M11", "149")!.Name;
+		var (kept, issues) = await Validate(Row("Fulmine", "M11", "149", language: "it"));
+
+		kept.Should().ContainSingle().Which.Card.Printing.Name.Should().Be(canonical);
+		issues.Should().ContainSingle().Which.Severity.Should().Be(IssueSeverity.Warning);
+	}
+
+	[Fact]
+	public async Task EnglishRow_NameMismatch_IsStillDropped()
+	{
+		var (kept, issues) = await Validate(Row("Fulmine", "M11", "149", language: "en"));
 
 		kept.Should().BeEmpty();
 		issues.Should().ContainSingle().Which.Severity.Should().Be(IssueSeverity.Error);

--- a/MtgCsvHelper/Enrichment/CatalogValidator.cs
+++ b/MtgCsvHelper/Enrichment/CatalogValidator.cs
@@ -7,7 +7,8 @@ namespace MtgCsvHelper.Enrichment;
 /// The one validator in the post-parse pipeline. Resolves each row to a catalog printing — by the
 /// Scryfall id when the row carries one (authoritative; survives sites that reshape collector
 /// numbers), else by (Set, CollectorNumber). Drops rows that don't resolve, whose Name doesn't match
-/// the resolved printing, or whose Finish claims an unsupported finish.
+/// the resolved printing (except non-English rows, whose localized name is replaced with a warning),
+/// or whose Finish claims an unsupported finish.
 /// Named "Validator" rather than "Enricher" because it mainly
 /// checks-and-drops; its only mutations are the issues collection, canonicalizing the
 /// name of a short-named or front-face-ambiguous double-faced card to the resolved printing,
@@ -73,12 +74,20 @@ public sealed class CatalogValidator(IReferenceCardCatalog catalog) : PerCardEnr
 		{
 			if (!EqualsNormalized(FrontFace(p.Name), FrontFace(match.Name)) && !ExtendsCanonicalName(p.Name, match.Name))
 			{
-				issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
-					$"Name '{p.Name}' does not match printing at {p.Set} #{p.CollectorNumber} ('{match.Name}')",
+				// A localized name can't match the English-only catalog; the resolved (Set, #) is the identity, so keep the row.
+				if (row.Card.Language is null or "en")
+				{
+					issues.Add(new ImportIssue(IssueSeverity.Error, row.RowNumber,
+						$"Name '{p.Name}' does not match printing at {p.Set} #{p.CollectorNumber} ('{match.Name}')",
+						CardName: p.Name, RawContent: row.RawContent));
+					return false;
+				}
+
+				issues.Add(new ImportIssue(IssueSeverity.Warning, row.RowNumber,
+					$"Non-English name '{p.Name}' replaced with '{match.Name}' from printing at {p.Set} #{p.CollectorNumber}",
 					CardName: p.Name, RawContent: row.RawContent));
-				return false;
 			}
-			// (Set, #) already pins the printing; adopt its canonical name for a short, shared-front-face, or decorated import.
+			// (Set, #) already pins the printing; adopt its canonical name for a short, shared-front-face, decorated, or localized import.
 			p.Name = match.Name;
 		}
 


### PR DESCRIPTION
## Summary

Addresses sub-problem 1 of #103 (foreign-language card names). The 1.5.0 stale-coordinate rewrite only helps rows whose `(Set, Collector#)` **doesn't** resolve; the remaining gap was rows where the coordinate resolves fine but the localized name (Italian `Fulmine`) can't match the English-only catalog — `CatalogValidator` dropped them as name-mismatch errors.

Now, when a row's Language column explicitly says non-English, the validator trusts the resolved coordinate: it adopts the catalog's English name and records a **Warning** (`Non-English name 'Fulmine' replaced with 'Lightning Bolt' from printing at M11 #149`) instead of dropping the row.

- English rows and rows without a Language value keep the strict corruption guard unchanged — the downgrade applies only to an explicit non-English language code.
- Recovers the 6-row `Name 'X' does not match printing` cluster from the #102 Italian Dragon Shield report.
- The regional set-code cluster (`LEGI`, sub-problem 2 of #103) is **not** covered here and stays open.

## Changes

- [`CatalogValidator`](https://github.com/StepKie/MtgCsvHelper/blob/develop/MtgCsvHelper/Enrichment/CatalogValidator.cs): non-English branch in the name-mismatch guard.
- Tests: `NonEnglishRow_NameMismatch_IsKeptWithEnglishName_AndWarning`, `EnglishRow_NameMismatch_IsStillDropped`; `Row` helper gained a `language` parameter.
- CHANGELOG entry under Unreleased.

## Test plan

- Full suite green locally (298/298, test project).
