### PR TITLE
Add bUnit component tests for MtgCsvProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Unreleased work targets the next minor version once a coherent feature set is re
 
 - **Exports match each site's native column layout** ([#134](https://github.com/StepKie/MtgCsvHelper/issues/134)). Every writable format now emits the site's full header set in the site's exact column order — instead of only the modeled columns in our own order. Strict, order-sensitive importers (Archidekt, TCGplayer) accept the files, and they diff cleanly against real site exports. Catalog-derived columns are filled (rarity, Multiverse Id, TCGplayer product id — extending the Scryfall id from 1.5.0); the rest are left blank. The native layout is declared per format in `appsettings.json` and anchored to a captured export by test.
 
+### Internal
+
+- **bUnit component tests for the web UI** ([#70](https://github.com/StepKie/MtgCsvHelper/issues/70)). New `MtgCsvHelper.BlazorWebAssembly.Tests` project covering the converter page: format dropdown contents, auto-detect on file upload, input/output collision snapping, the header-mismatch error alert, and the catalog-load failure/retry path.
+
 ## [1.5.0] — 2026-07-03
 
 ### Added

--- a/MtgCsvHelper.BlazorWebAssembly.Tests/MtgCsvHelper.BlazorWebAssembly.Tests.csproj
+++ b/MtgCsvHelper.BlazorWebAssembly.Tests/MtgCsvHelper.BlazorWebAssembly.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageReference Include="bunit" Version="2.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MtgCsvHelper.BlazorWebAssembly\MtgCsvHelper.BlazorWebAssembly.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MtgCsvHelper.BlazorWebAssembly.Tests/MtgCsvProcessorTests.cs
+++ b/MtgCsvHelper.BlazorWebAssembly.Tests/MtgCsvProcessorTests.cs
@@ -25,8 +25,7 @@ public class MtgCsvProcessorTests : BunitContext, IAsyncLifetime
 	public Task InitializeAsync() => Task.CompletedTask;
 	Task IAsyncLifetime.DisposeAsync() => DisposeAsync().AsTask();
 
-	// MudSelect popovers render their content under a MudPopoverProvider, so the page is rendered
-	// alongside one and tests search from the shared root.
+	// MudSelect popovers teleport into a MudPopoverProvider, so the page renders alongside one and tests search from the shared root.
 	IRenderedComponent<IComponent> RenderProcessor() => Render(b =>
 	{
 		b.OpenComponent<MudPopoverProvider>(0);
@@ -122,6 +121,22 @@ public class MtgCsvProcessorTests : BunitContext, IAsyncLifetime
 		await root.FindAll("button").Single(b => b.TextContent.Contains("Convert")).ClickAsync(new());
 
 		await root.WaitForAssertionAsync(() => root.FindComponent<MudAlert>().Markup.Should().Contain("missing required column"));
+	}
+
+	// Covers the page's StateChanged += StateHasChanged subscription: loader progress must re-render without user input.
+	[Fact]
+	public async Task CatalogLoadProgress_UpdatesUiOnStateChange()
+	{
+		_catalogLoader.Catalog = null;
+		_catalogLoader.Progress = CatalogLoadProgress.Idle;
+
+		var root = RenderProcessor();
+		root.Markup.Should().NotContain("Loading card data");
+
+		_catalogLoader.Progress = new(CatalogLoadPhase.Downloading, 42, 42, 100);
+		await root.InvokeAsync(_catalogLoader.RaiseStateChanged);
+
+		root.Markup.Should().Contain("Loading card data… 42%");
 	}
 
 	[Fact]

--- a/MtgCsvHelper.BlazorWebAssembly.Tests/MtgCsvProcessorTests.cs
+++ b/MtgCsvHelper.BlazorWebAssembly.Tests/MtgCsvProcessorTests.cs
@@ -1,0 +1,140 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MtgCsvHelper.Services;
+using MudBlazor.Services;
+
+namespace MtgCsvHelper.BlazorWebAssembly.Tests;
+
+public class MtgCsvProcessorTests : BunitContext, IAsyncLifetime
+{
+	readonly FakeCatalogLoader _catalogLoader = new();
+	readonly IConfiguration _config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+
+	public MtgCsvProcessorTests()
+	{
+		JSInterop.Mode = JSRuntimeMode.Loose;
+		Services.AddMudServices();
+		Services.AddSingleton(_config);
+		Services.AddSingleton<ICatalogLoader>(_catalogLoader);
+		Services.AddSingleton<ICardmarketResolver>(new FakeCardmarketResolver());
+	}
+
+	// Some MudBlazor services are IAsyncDisposable-only; the context must be torn down via DisposeAsync.
+	public Task InitializeAsync() => Task.CompletedTask;
+	Task IAsyncLifetime.DisposeAsync() => DisposeAsync().AsTask();
+
+	// MudSelect popovers render their content under a MudPopoverProvider, so the page is rendered
+	// alongside one and tests search from the shared root.
+	IRenderedComponent<IComponent> RenderProcessor() => Render(b =>
+	{
+		b.OpenComponent<MudPopoverProvider>(0);
+		b.CloseComponent();
+		b.OpenComponent<MtgCsvProcessor>(1);
+		b.CloseComponent();
+	});
+
+	static IRenderedComponent<MudSelect<string>> Select(IRenderedComponent<IComponent> root, string label) =>
+		root.FindComponents<MudSelect<string>>().Single(s => s.Instance.Label == label);
+
+	static void Upload(IRenderedComponent<IComponent> root, string csvContent) =>
+		root.FindComponent<InputFile>().UploadFiles(InputFileContent.CreateFromText(csvContent, "upload.csv"));
+
+	static string FixtureCsv(string name) =>
+		File.ReadAllText(Path.Combine("Resources", "SampleCsvs", "Reference", name));
+
+	[Fact]
+	public void FormatSelects_OfferReadableInputsAndWritableOutputs()
+	{
+		var root = RenderProcessor();
+
+		// Items render in page order — the input select and its items precede the output select's.
+		root.FindComponents<MudSelectItem<string>>().Select(i => i.Instance.Value)
+			.Should().Equal(CardMapFactory.ReadableFormats.Concat(CardMapFactory.WritableFormats));
+	}
+
+	[Fact]
+	public void InitialFormats_Differ()
+	{
+		var root = RenderProcessor();
+
+		Select(root, "Input format").Instance.GetState(x => x.Value)
+			.Should().NotBe(Select(root, "Output format").Instance.GetState(x => x.Value));
+	}
+
+	[Fact]
+	public async Task FileUpload_AutoDetectsInputFormat()
+	{
+		var csv = FixtureCsv("moxfield.csv");
+		var detector = new FormatDetector([.. CardMapFactory.SupportedConfigs(_config)]);
+		var expected = detector.Detect(csv.Split('\n')[0]);
+		expected.Should().NotBeNull(because: "the reference fixture must be detectable, or the test asserts nothing");
+
+		var root = RenderProcessor();
+		await root.InvokeAsync(() => Upload(root, csv));
+
+		await root.WaitForAssertionAsync(() => Select(root, "Input format").Instance.GetState(x => x.Value).Should().Be(expected));
+	}
+
+	[Fact]
+	public async Task PickingOutputEqualToInput_SnapsInputToDifferentFormat()
+	{
+		var root = RenderProcessor();
+		var collision = Select(root, "Input format").Instance.GetState(x => x.Value)!;
+
+		await root.InvokeAsync(() => Select(root, "Output format").Instance.ValueChanged.InvokeAsync(collision));
+
+		Select(root, "Output format").Instance.GetState(x => x.Value).Should().Be(collision);
+		Select(root, "Input format").Instance.GetState(x => x.Value).Should().NotBe(collision);
+	}
+
+	[Fact]
+	public async Task PickingInputEqualToOutput_SnapsOutputToDifferentFormat()
+	{
+		var root = RenderProcessor();
+		var collision = Select(root, "Output format").Instance.GetState(x => x.Value)!;
+
+		await root.InvokeAsync(() => Select(root, "Input format").Instance.ValueChanged.InvokeAsync(collision));
+
+		Select(root, "Input format").Instance.GetState(x => x.Value).Should().Be(collision);
+		Select(root, "Output format").Instance.GetState(x => x.Value).Should().NotBe(collision);
+	}
+
+	[Fact]
+	public async Task UndetectableCsv_ReenablesManualInputPick()
+	{
+		var root = RenderProcessor();
+		Select(root, "Input format").Instance.Disabled
+			.Should().BeTrue(because: "auto-detect owns the input pick until it fails");
+
+		await root.InvokeAsync(() => Upload(root, "foo,bar\n1,2\n"));
+
+		await root.WaitForAssertionAsync(() => Select(root, "Input format").Instance.Disabled.Should().BeFalse());
+	}
+
+	[Fact]
+	public async Task ConvertingCsvThatDoesNotMatchSelectedFormat_ShowsHeaderError()
+	{
+		var root = RenderProcessor();
+		await root.InvokeAsync(() => Upload(root, "foo,bar\n1,2\n"));
+
+		await root.FindAll("button").Single(b => b.TextContent.Contains("Convert")).ClickAsync(new());
+
+		await root.WaitForAssertionAsync(() => root.FindComponent<MudAlert>().Markup.Should().Contain("missing required column"));
+	}
+
+	[Fact]
+	public async Task FailedCatalogLoad_ShowsError_AndRetryReloads()
+	{
+		_catalogLoader.Catalog = null;
+		_catalogLoader.Error = new InvalidOperationException("bundle fetch failed");
+		_catalogLoader.Progress = new(CatalogLoadPhase.Failed, 0, 0, null);
+
+		var root = RenderProcessor();
+
+		root.Markup.Should().Contain("Card data failed to load").And.Contain("bundle fetch failed");
+		await root.FindAll("button").Single(b => b.TextContent.Contains("Retry")).ClickAsync(new());
+		_catalogLoader.LoadCalls.Should().Be(1);
+	}
+}

--- a/MtgCsvHelper.BlazorWebAssembly.Tests/TestDoubles.cs
+++ b/MtgCsvHelper.BlazorWebAssembly.Tests/TestDoubles.cs
@@ -1,0 +1,27 @@
+using MtgCsvHelper.Services;
+
+namespace MtgCsvHelper.BlazorWebAssembly.Tests;
+
+/// <summary> Catalog loader with settable state; defaults to a ready, empty catalog. </summary>
+sealed class FakeCatalogLoader : ICatalogLoader
+{
+	public IReferenceCardCatalog? Catalog { get; set; } = new ReferenceCardCatalog([]);
+	public CatalogLoadProgress Progress { get; set; } = new(CatalogLoadPhase.Ready, 100, 0, null);
+	public Exception? Error { get; set; }
+	public event Action? StateChanged;
+	public int LoadCalls { get; private set; }
+
+	public Task LoadAsync(CancellationToken ct = default)
+	{
+		LoadCalls++;
+		return Task.CompletedTask;
+	}
+
+	public void RaiseStateChanged() => StateChanged?.Invoke();
+}
+
+sealed class FakeCardmarketResolver : ICardmarketResolver
+{
+	public Task<IReadOnlyDictionary<int, ReferenceCard>> ResolveAsync(IEnumerable<int> cardmarketIds, CancellationToken ct = default) =>
+		Task.FromResult<IReadOnlyDictionary<int, ReferenceCard>>(new Dictionary<int, ReferenceCard>());
+}

--- a/MtgCsvHelper.BlazorWebAssembly.Tests/Usings.cs
+++ b/MtgCsvHelper.BlazorWebAssembly.Tests/Usings.cs
@@ -1,0 +1,7 @@
+global using AwesomeAssertions;
+global using Bunit;
+global using MtgCsvHelper;
+global using MtgCsvHelper.BlazorWebAssembly.Pages;
+global using MudBlazor;
+global using MudBlazor.Extensions;
+global using Xunit;

--- a/MtgCsvHelper.slnx
+++ b/MtgCsvHelper.slnx
@@ -3,6 +3,7 @@
     <File Path=".editorconfig" />
     <File Path="README.md" />
   </Folder>
+  <Project Path="MtgCsvHelper.BlazorWebAssembly.Tests/MtgCsvHelper.BlazorWebAssembly.Tests.csproj" />
   <Project Path="MtgCsvHelper.BlazorWebAssembly/MtgCsvHelper.BlazorWebAssembly.csproj" />
   <Project Path="MtgCsvHelper.Console/MtgCsvHelper.Console.csproj" />
   <Project Path="MtgCsvHelper.Tests/MtgCsvHelper.Tests.csproj" />


### PR DESCRIPTION
## Summary

Closes the remaining scope of #70 (the parser/handler items were retired as already-covered — see [the status trim comment](https://github.com/StepKie/MtgCsvHelper/issues/70#issuecomment-4887315749)): the `MtgCsvProcessor` page — the largest piece of UI logic in the project — now has component tests.

New **`MtgCsvHelper.BlazorWebAssembly.Tests`** project (bUnit 2.7.2, xunit, AwesomeAssertions) with eight tests against the real rendered page:

- Format dropdowns offer exactly `CardMapFactory.ReadableFormats` / `WritableFormats`
- Initial input format ≠ output format
- File upload auto-detects the input format (expectation derived by running `FormatDetector` on the committed `moxfield.csv` reference fixture)
- Collision snapping in both directions (picking output == input snaps input away, and vice versa)
- An undetectable CSV re-enables the manual input pick
- Converting a CSV that doesn't match the selected format shows the header-error alert
- Catalog-load failure renders the error and Retry re-triggers `LoadAsync`

## Test doubles

Minimal, pipeline stays real: `FakeCatalogLoader` (settable phase/error, counts `LoadAsync` calls) around a real-but-empty `ReferenceCardCatalog`, plus a no-op `ICardmarketResolver`. No production code changed.

## MudBlazor-under-bUnit notes

- MudSelect teleports its items into a `MudPopoverProvider`, so the page renders next to one and item assertions search from the shared root; `MudSelect.Items` never populates in this setup, so the test asserts on the rendered `MudSelectItem` components (page order: input items before output items).
- `Value` reads use `GetState(x => x.Value)` per the MUD0012 analyzer.
- Teardown goes through `IAsyncLifetime` because some MudBlazor services only implement `IAsyncDisposable`.

## Test plan

- Full solution suite green locally: 298 (existing) + 8 (new).
- CI runs the new project automatically (`dotnet test` on the solution; the workflow already installs `wasm-tools`).
